### PR TITLE
chore: bump go-jsonschema to fix invalid escape sequence error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,16 @@ go 1.21
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
-	github.com/alexbrdn/go-jsonschema v0.0.0-20231107145722-e86784632bf6
+	github.com/alexbrdn/go-jsonschema v0.0.0-20231121132002-1f925471ed53
+	github.com/buger/jsonparser v1.1.1
 	github.com/go-playground/validator/v10 v10.15.5
+	github.com/kennygrant/sanitize v1.2.4
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.17.0
 	github.com/stretchr/testify v1.8.4
 )
 
 require (
-	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
@@ -20,7 +21,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/kennygrant/sanitize v1.2.4 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
-github.com/alexbrdn/go-jsonschema v0.0.0-20231107145722-e86784632bf6 h1:Yb0GEsxHKt5w1oqOirKlSANz1Bht6blPPjNMHSwFUe0=
-github.com/alexbrdn/go-jsonschema v0.0.0-20231107145722-e86784632bf6/go.mod h1:XAZNOA9R5wFapXEPnjpZhEdkHtgDFERvm/A+9VmwEiA=
+github.com/alexbrdn/go-jsonschema v0.0.0-20231121132002-1f925471ed53 h1:rtyKdphqjcnKOID3gCz1s+gSnxQL/rEBJab8nkOqaB8=
+github.com/alexbrdn/go-jsonschema v0.0.0-20231121132002-1f925471ed53/go.mod h1:XAZNOA9R5wFapXEPnjpZhEdkHtgDFERvm/A+9VmwEiA=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
- fix: fixed the mistaken error message on validation when e.g. a property description string contains a [properly escaped] backslash