### PR TITLE
fix: do not create toc if no remote could be determined

### DIFF
--- a/cmd/create-toc.go
+++ b/cmd/create-toc.go
@@ -29,14 +29,15 @@ func executeCreateTOC(cmd *cobra.Command, args []string) {
 
 	remote, err := remotes.Get(remoteName)
 	if err != nil {
+		//TODO: log to stderr or logger ?
 		log.Error(fmt.Sprintf("could not initialize a remote instance for %s. check config", remoteName), "error", err)
+		os.Exit(1)
 	}
 
-	if err == nil {
-		err = remote.CreateToC()
-	}
+	err = remote.CreateToC()
 
 	if err != nil {
+		//TODO: log to stderr or logger ?
 		log.Error(err.Error())
 		os.Exit(1)
 	}

--- a/cmd/create-toc.go
+++ b/cmd/create-toc.go
@@ -32,7 +32,10 @@ func executeCreateTOC(cmd *cobra.Command, args []string) {
 		log.Error(fmt.Sprintf("could not initialize a remote instance for %s. check config", remoteName), "error", err)
 	}
 
-	err = remote.CreateToC()
+	if err == nil {
+		err = remote.CreateToC()
+	}
+
 	if err != nil {
 		log.Error(err.Error())
 		os.Exit(1)


### PR DESCRIPTION
Fixes following bug:
If there are multiple remotes defined in the config, and none of the remotes is marked with "default" true,
then a remote can not be determined and the create-toc fails with a panic.