### PR TITLE
feat: enable disable logging

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,8 @@ var RootCmd = &cobra.Command{
 ThingModel catalogs.`,
 }
 
+var log bool
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the RootCmd.
 func Execute() {
@@ -24,7 +26,7 @@ func Execute() {
 }
 
 func init() {
-
+	RootCmd.PersistentFlags().BoolVarP(&log, "log", "l", false, "enable logging")
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal/config"
+	"log/slog"
+	"testing"
+)
+
+func TestLoggingOnSubCommands(t *testing.T) {
+	config.InitViper()
+	RootCmd.ResetCommands()
+
+	var isDisabled bool
+
+	// given: some sub-commands of the root command
+	//        where the "serve" command is to be expected having logging enabled default
+	runFunc := func(cmd *cobra.Command, args []string) {
+		hdl := slog.Default().Handler()
+		_, isDisabled = hdl.(*internal.DiscardLogHandler)
+	}
+
+	var listCmd = &cobra.Command{Use: "list", Run: runFunc}
+	var serveCmd = &cobra.Command{Use: "serve", Run: runFunc}
+	var pushCmd = &cobra.Command{Use: "push", Run: runFunc}
+
+	RootCmd.AddCommand(listCmd, serveCmd, pushCmd)
+
+	// when: executing the list command
+	RootCmd.SetArgs([]string{"list"})
+	_ = RootCmd.Execute()
+	// then: logging is default DISABLED
+	assert.True(t, isDisabled)
+
+	// when: executing the serve command
+	RootCmd.SetArgs([]string{"serve"})
+	_ = RootCmd.Execute()
+	// then: logging is default ENABLED
+	assert.False(t, isDisabled)
+
+	// when: executing the push command
+	RootCmd.SetArgs([]string{"push"})
+	_ = RootCmd.Execute()
+	// then: logging is default DISABLED
+	assert.True(t, isDisabled)
+}
+
+func TestLogFlagEnablesLogging(t *testing.T) {
+	config.InitViper()
+	RootCmd.ResetCommands()
+
+	var isDisabled bool
+
+	// given: a sub-command of the root command
+	runFunc := func(cmd *cobra.Command, args []string) {
+		hdl := slog.Default().Handler()
+		_, isDisabled = hdl.(*internal.DiscardLogHandler)
+	}
+
+	var pushCmd = &cobra.Command{Use: "push", Run: runFunc}
+	RootCmd.AddCommand(pushCmd)
+
+	// when: executing the command with the --log flag
+	RootCmd.SetArgs([]string{"push"})
+	_ = RootCmd.ParseFlags([]string{"--log", ""})
+	_ = RootCmd.Execute()
+	// then: logging is ENABLED
+	assert.False(t, isDisabled)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,15 @@
 package config
 
 import (
+	"github.com/spf13/viper"
 	"os"
 	"path/filepath"
+)
+
+const (
+	KeyLog      = "log"
+	KeyLogLevel = "logLevel"
+	EnvPrefix   = "tmc"
 )
 
 var HomeDir string
@@ -15,4 +22,40 @@ func init() {
 		panic(err)
 	}
 	DefaultConfigDir = filepath.Join(HomeDir, ".tm-catalog")
+
+	InitViper()
+}
+
+func InitViper() {
+	viper.SetDefault(KeyLog, false)
+	viper.SetDefault(KeyLogLevel, "INFO")
+	viper.SetDefault("remotes", map[string]any{
+		"local": map[string]any{
+			"type": "file",
+			"loc":  "~/tm-catalog",
+		},
+	})
+
+	viper.SetConfigType("json")
+	viper.SetConfigName("config")
+	viper.AddConfigPath(DefaultConfigDir)
+	viper.AddConfigPath(".")
+	err := viper.ReadInConfig()
+	if err != nil {
+		if err := viper.ReadInConfig(); err != nil {
+			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+				// Config file not found; do nothing and rely on defaults
+			} else {
+				panic("cannot read config: " + err.Error())
+			}
+		}
+	}
+
+	// set prefix "tmc" for environment variables
+	// the environment variables then have to match pattern "tmc_<viper variable>", lower or uppercase
+	viper.SetEnvPrefix(EnvPrefix)
+	// bind viper variable "log" to env (tmc_log or TMC_LOG)
+	_ = viper.BindEnv(KeyLog)
+
+	viper.WatchConfig()
 }

--- a/internal/log.go
+++ b/internal/log.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"github.com/spf13/viper"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal/config"
+	"io"
+	"log/slog"
+	"os"
+)
+
+type DefaultLogHandler struct {
+	*slog.TextHandler
+}
+
+type DiscardLogHandler struct {
+	*slog.TextHandler
+}
+
+func newDefaultLogHandler(opts *slog.HandlerOptions) slog.Handler {
+	return &DefaultLogHandler{
+		TextHandler: slog.NewTextHandler(os.Stderr, opts),
+	}
+}
+
+func newDiscardLogHandler(opts *slog.HandlerOptions) slog.Handler {
+	return &DiscardLogHandler{
+		TextHandler: slog.NewTextHandler(io.Discard, opts),
+	}
+}
+
+func InitLogging() {
+	logEnabled := viper.GetBool(config.KeyLog)
+
+	logLevel := viper.GetString(config.KeyLogLevel)
+	var level slog.Level
+	//levelP := &level
+	err := level.UnmarshalText([]byte(logLevel))
+	if err != nil {
+		level = slog.LevelInfo
+	}
+
+	opts := &slog.HandlerOptions{
+		Level: level,
+	}
+
+	var handler slog.Handler
+	if logEnabled {
+		handler = newDefaultLogHandler(opts)
+	} else {
+		handler = newDiscardLogHandler(opts)
+	}
+
+	log := slog.New(handler)
+	slog.SetDefault(log)
+}

--- a/internal/log_test.go
+++ b/internal/log_test.go
@@ -1,0 +1,40 @@
+package internal
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal/config"
+	"log/slog"
+	"testing"
+)
+
+const envVarLog = config.EnvPrefix + "_" + config.KeyLog
+
+func TestLogDisabledDefault(t *testing.T) {
+	// given: default environment with no env var set that would enable logging
+	t.Setenv(envVarLog, "")
+	config.InitViper()
+
+	// when: initialize the logging
+	InitLogging()
+	hdl := slog.Default().Handler()
+	_, isDiscardHandler := hdl.(*DiscardLogHandler)
+
+	// then: the logs are written to the discard handler
+	assert.True(t, isDiscardHandler)
+}
+
+func TestLogEnabledByEnvVar(t *testing.T) {
+	// given: environment with env var set that enables logging
+	t.Setenv(envVarLog, "true")
+	config.InitViper()
+
+	// when: initialize the logging
+	InitLogging()
+	hdl := slog.Default().Handler()
+	_, isDefaultHandler := hdl.(*DefaultLogHandler)
+
+	// then: the logs are written to the default handler
+	assert.True(t, isDefaultHandler)
+
+	t.Setenv(envVarLog, "")
+}

--- a/main.go
+++ b/main.go
@@ -4,52 +4,10 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package main
 
 import (
-	"github.com/spf13/viper"
 	"github.com/web-of-things-open-source/tm-catalog-cli/cmd"
 	_ "github.com/web-of-things-open-source/tm-catalog-cli/cmd/remote"
-	"github.com/web-of-things-open-source/tm-catalog-cli/internal/config"
 )
 
 func main() {
 	cmd.Execute()
-}
-
-func init() {
-	initViper()
-}
-
-func initViper() {
-	viper.SetDefault("log", false)
-	viper.SetDefault("logLevel", "INFO")
-	viper.SetDefault("remotes", map[string]any{
-		"local": map[string]any{
-			"type": "file",
-			"loc":  "~/tm-catalog",
-		},
-	})
-
-	viper.SetConfigType("json")
-	viper.SetConfigName("config")
-	viper.AddConfigPath(config.DefaultConfigDir)
-	viper.AddConfigPath(".")
-	err := viper.ReadInConfig()
-	if err != nil {
-		if err := viper.ReadInConfig(); err != nil {
-			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-				// Config file not found; do nothing and rely on defaults
-			} else {
-				panic("cannot read config: " + err.Error())
-			}
-		}
-	}
-
-	// set prefix "tmc" for environment variables
-	// the environment variables then have to match pattern "tmc_<viper variable>", lower or uppercase
-	viper.SetEnvPrefix("tmc")
-	// bind viper variable "log" to env (tmc_log or TMC_LOG)
-	_ = viper.BindEnv("log")
-	// bind viper variable "log" also to CLI flag --log of root command
-	_ = viper.BindPFlag("log", cmd.RootCmd.PersistentFlags().Lookup("log"))
-
-	viper.WatchConfig()
 }

--- a/main.go
+++ b/main.go
@@ -4,13 +4,15 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package main
 
 import (
+	"github.com/spf13/cobra"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal/config"
+	"io"
 	"log/slog"
 	"os"
 
 	"github.com/spf13/viper"
 	"github.com/web-of-things-open-source/tm-catalog-cli/cmd"
 	_ "github.com/web-of-things-open-source/tm-catalog-cli/cmd/remote"
-	"github.com/web-of-things-open-source/tm-catalog-cli/internal/config"
 )
 
 func main() {
@@ -18,18 +20,23 @@ func main() {
 }
 
 func init() {
-	initViper()
-	setUpLogger()
+	cobra.OnInitialize(configureCLI)
 }
 
-func initViper() {
+func configureCLI() {
+	configureViper()
+	configureLogger()
+}
+
+func configureViper() {
+	viper.SetDefault("log", false)
+	viper.SetDefault("logLevel", "INFO")
 	viper.SetDefault("remotes", map[string]any{
 		"local": map[string]any{
 			"type": "file",
 			"loc":  "~/tm-catalog",
 		},
 	})
-	viper.SetDefault("logLevel", "INFO")
 
 	viper.SetConfigType("json")
 	viper.SetConfigName("config")
@@ -45,9 +52,20 @@ func initViper() {
 			}
 		}
 	}
+
+	_ = viper.BindEnv("log")
+	_ = viper.BindPFlag("log", cmd.RootCmd.PersistentFlags().Lookup("log"))
+
 	viper.WatchConfig()
 }
-func setUpLogger() {
+
+func configureLogger() {
+	logEnabled := viper.GetBool("log")
+	var writer = io.Discard
+	if logEnabled {
+		writer = os.Stderr
+	}
+
 	logLevel := viper.GetString("logLevel")
 	var level slog.Level
 	//levelP := &level
@@ -58,7 +76,8 @@ func setUpLogger() {
 	opts := &slog.HandlerOptions{
 		Level: level,
 	}
-	handler := slog.NewTextHandler(os.Stderr, opts)
+
+	handler := slog.NewTextHandler(writer, opts)
 	log := slog.New(handler)
 	slog.SetDefault(log)
 }


### PR DESCRIPTION
Changes: 

+ enables logging for commands via
   + passing `--log / -l` flag on command line
   + setting environment variable, e.g. `export tmc_log=true` 
   + setting  `"log": true` in config.json

+ per default, logging for `serve` command is enabled, for other commands disabled 