### PR TITLE
feat: api extension

### DIFF
--- a/api/tm-catalog.openapi.yaml
+++ b/api/tm-catalog.openapi.yaml
@@ -27,46 +27,46 @@ paths:
       description: Returns the catalogs inventory
       operationId: getInventory
       parameters:
-        - name: filter[author]
+        - name: 'filter.author'
           in: query
           description: |
             Filters the inventory by one or more authors having exact match.  
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[author]=MyCompany,YourCompany
-        - name: filter[manufacturer]
+          example: filter.author=MyCompany,YourCompany
+        - name: 'filter.manufacturer'
           in: query
           description: |
             Filters the inventory by one or more manufacturers having exact match.  
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[manufacturer]=ABB,Danfoss
-        - name: filter[mpn]
+          example: filter.manufacturer=ABB,Danfoss
+        - name: 'filter.mpn'
           in: query
           description: |
             Filters the inventory by one ore more mpn (manufacturer part number) having exact match.   
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[mpn]=B21,FC102
-        - name: filter[externalID]
+          example: filter.mpn=B21,FC102
+        - name: 'filter.externalID'
           in: query
           description: |
             Filters the inventory by one or more external ID having exact match.   
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[externalID]=12345,7c9691d0-8b05-11ee-b9d1-0242ac120002
-        - name: search[content]
+          example: filter.externalID=12345,7c9691d0-8b05-11ee-b9d1-0242ac120002
+        - name: 'search.content'
           in: query
           description: |
             Filters the inventory according to whether the content of the inventory entries matches the given search.    
             The search works additive to other filters.
           schema:
             type: string
-          example: search[content]=
+          example: search.content=
         - name: sort
           in: query
           description: |
@@ -288,7 +288,7 @@ paths:
       description: Returns the contained authors of the inventory
       operationId: getAuthors
       parameters:
-        - name: filter[manufacturer]
+        - name: 'filter.manufacturer'
           in: query
           description: |
             Filters the authors according to whether they have inventory entries  
@@ -296,8 +296,8 @@ paths:
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[manufacturer]=ABB,Danfoss
-        - name: filter[mpn]
+          example: filter.manufacturer=ABB,Danfoss
+        - name: 'filter.mpn'
           in: query
           description: |
             Filters the authors according to whether they have inventory entries    
@@ -305,8 +305,8 @@ paths:
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[mpn]=B21,FC102
-        - name: filter[externalID]
+          example: filter.mpn=B21,FC102
+        - name: 'filter.externalID'
           in: query
           description: |
             Filters the authors according to whether they have inventory entries   
@@ -314,8 +314,8 @@ paths:
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[externalID]=12345,7c9691d0-8b05-11ee-b9d1-0242ac120002
-        - name: search[content]
+          example: filter.externalID=12345,7c9691d0-8b05-11ee-b9d1-0242ac120002
+        - name: 'search.content'
           in: query
           description: |
             Filters the authors according to whether they have inventory entries  
@@ -355,15 +355,15 @@ paths:
       description: Returns the contained manufacturers of the inventory
       operationId: getManufacturers
       parameters:
-        - name: filter[author]
+        - name: 'filter.author'
           in: query
           description: |
             Filters the manufacturers according to whether they belong to at least one of the given authors with an exact match.       
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[author]=MyCompany,YourCompany
-        - name: filter[mpn]
+          example: filter.author=MyCompany,YourCompany
+        - name: 'filter.mpn'
           in: query
           description: |
             Filters the manufacturers according to whether they have inventory entries    
@@ -371,8 +371,8 @@ paths:
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[mpn]=B21,FC102
-        - name: filter[externalID]
+          example: filter.mpn=B21,FC102
+        - name: 'filter.externalID'
           in: query
           description: |
             Filters the manufacturers according to whether they have inventory entries   
@@ -380,8 +380,8 @@ paths:
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[externalID]=12345,7c9691d0-8b05-11ee-b9d1-0242ac120002
-        - name: search[content]
+          example: filter.externalID=12345,7c9691d0-8b05-11ee-b9d1-0242ac120002
+        - name: 'search.content'
           in: query
           description: |
             Filters the manufacturers according to whether they have inventory entries  
@@ -421,23 +421,23 @@ paths:
       description: Returns the mpns (manufacturer part numbers) of the inventory
       operationId: getMpns
       parameters:
-        - name: filter[author]
+        - name: 'filter.author'
           in: query
           description: |
             Filters the mpns according to whether they belong to at least one of the given authors with an exact match.     
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[author]=MyCompany,YourCompany
-        - name: filter[manufacturer]
+          example: filter.author=MyCompany,YourCompany
+        - name: 'filter.manufacturer'
           in: query
           description: |
             Filters the mpns according to whether they belong to at least one of the given manufacturers with an exact match.     
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[manufacturer]=ABB,Danfoss
-        - name: filter[externalID]
+          example: filter.manufacturer=ABB,Danfoss
+        - name: 'filter.externalID'
           in: query
           description: |
             Filters the mpns according to whether their inventory entry   
@@ -445,8 +445,8 @@ paths:
             The filter works additive to other filters.
           schema:
             type: string
-          example: filter[externalID]=12345,7c9691d0-8b05-11ee-b9d1-0242ac120002
-        - name: search[content]
+          example: filter.externalID=12345,7c9691d0-8b05-11ee-b9d1-0242ac120002
+        - name: 'search.content'
           in: query
           description: |
             Filters the mpns according to whether their inventory entry content matches the given search.        

--- a/api/tm-catalog.openapi.yaml
+++ b/api/tm-catalog.openapi.yaml
@@ -18,6 +18,8 @@ tags:
     description: Access to manufacturers information
   - name: mpns
     description: Access to mpns (manufacturer part numbers) information
+  - name: health
+    description: Access to health information
 paths:
   /inventory:
     get:
@@ -99,8 +101,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-      security:
-        - api_key: []
   /inventory/{name}:
     get:
       tags:
@@ -144,8 +144,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-      security:
-        - api_key: []
   /inventory/{name}/versions:
     get:
       tags:
@@ -189,8 +187,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-      security:
-        - api_key: []
   /thing-models/{tmID}:
     get:
       tags:
@@ -233,8 +229,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-      security:
-        - api_key: []
   /thing-models:
     post:
       tags:
@@ -277,9 +271,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-      security:
-        - api_key: [ ]
-
   /authors:
     get:
       tags:
@@ -345,8 +336,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-      security:
-        - api_key: [ ]
   /manufacturers:
     get:
       tags:
@@ -411,8 +400,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-      security:
-        - api_key: [ ]
   /mpns:
     get:
       tags:
@@ -475,8 +462,94 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-      security:
-        - api_key: [ ]
+  /healthz:
+    get:
+      tags:
+        - health
+      summary: Get the overall health of the service
+      description: Get the overall health of the service, aggregates the responses from the /health/live and /health/ready
+      operationId: getHealth
+      responses:
+        '204':
+          description: Successful operation
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                default: 'no-cache, no-store, max-age=0, must-revalidate'
+              description: "no-cache, no-store, max-age=0, must-revalidate"
+        '503':
+          description: Service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /healthz/live:
+    get:
+      tags:
+        - health
+      summary: Returns the liveliness of the service
+      description: Returns the liveliness of the service, or whether it encountered a bug or deadlock
+      operationId: getHealthLive
+      responses:
+        '204':
+          description: Successful operation
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                default: 'no-cache, no-store, max-age=0, must-revalidate'
+              description: "no-cache, no-store, max-age=0, must-revalidate"
+        '503':
+          description: Service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /healthz/ready:
+    get:
+      tags:
+        - health
+      summary: Returns the readiness of the service
+      description: Returns the readiness of the service, or whether it is ready to process requests
+      operationId: getHealthReady
+      responses:
+        '204':
+          description: Successful operation
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                default: 'no-cache, no-store, max-age=0, must-revalidate'
+              description: "no-cache, no-store, max-age=0, must-revalidate"
+        '503':
+          description: Service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /healthz/startup:
+    get:
+      tags:
+        - health
+      summary: Returns whether the service is initialized
+      description: Returns whether the service is initialized
+      operationId: getHealthStartup
+      responses:
+        '204':
+          description: Successful operation
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                default: 'no-cache, no-store, max-age=0, must-revalidate'
+              description: "no-cache, no-store, max-age=0, must-revalidate"
+        '503':
+          description: Service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
     InventoryEntry:
@@ -669,11 +742,6 @@ components:
           type: string
         status:
           type: integer
-  securitySchemes:
-    api_key:
-      type: apiKey
-      name: api_key
-      in: header
   examples:
     InventoryEntryVersionsResponseExample:
       value:

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -22,16 +22,16 @@ func init() {
 	RootCmd.AddCommand(serveCmd)
 	serveCmd.Flags().StringP("host", "", "0.0.0.0", "serve with this host name")
 	serveCmd.Flags().StringP("port", "", "8080", "serve with this port")
-	serveCmd.Flags().StringP("contextRoot", "", "", "define additional context root path")
-	_ = viper.BindPFlag(config.KeyContextRoot, serveCmd.Flags().Lookup("contextRoot"))
+	serveCmd.Flags().StringP("urlContextRoot", "", "", "define additional URL context root path to be considered in hypermedia links")
+	_ = viper.BindPFlag(config.KeyUrlContextRoot, serveCmd.Flags().Lookup("urlContextRoot"))
 }
 
 func serve(cmd *cobra.Command, args []string) {
 	host := cmd.Flag("host").Value.String()
 	port := cmd.Flag("port").Value.String()
-	ctxRoot := viper.GetString(config.KeyContextRoot)
+	urlCtxRoot := viper.GetString(config.KeyUrlContextRoot)
 
-	err := cli.Serve(host, port, ctxRoot)
+	err := cli.Serve(host, port, urlCtxRoot)
 	if err != nil {
 		cli.Stderrf("serve failed")
 		os.Exit(1)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"os"
 
+	"github.com/spf13/viper"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal/config"
+
 	"github.com/spf13/cobra"
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/app/cli"
 )
@@ -20,14 +23,15 @@ func init() {
 	serveCmd.Flags().StringP("host", "", "0.0.0.0", "serve with this host name")
 	serveCmd.Flags().StringP("port", "", "8080", "serve with this port")
 	serveCmd.Flags().StringP("contextRoot", "", "", "define additional context root path")
+	_ = viper.BindPFlag(config.KeyContextRoot, serveCmd.Flags().Lookup("contextRoot"))
 }
 
 func serve(cmd *cobra.Command, args []string) {
 	host := cmd.Flag("host").Value.String()
 	port := cmd.Flag("port").Value.String()
-	cr := cmd.Flag("contextRoot").Value.String()
+	ctxRoot := viper.GetString(config.KeyContextRoot)
 
-	err := cli.Serve(host, port, cr)
+	err := cli.Serve(host, port, ctxRoot)
 	if err != nil {
 		cli.Stderrf("serve failed")
 		os.Exit(1)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -22,7 +22,8 @@ func init() {
 	RootCmd.AddCommand(serveCmd)
 	serveCmd.Flags().StringP("host", "", "0.0.0.0", "serve with this host name")
 	serveCmd.Flags().StringP("port", "", "8080", "serve with this port")
-	serveCmd.Flags().StringP("urlContextRoot", "", "", "define additional URL context root path to be considered in hypermedia links")
+	serveCmd.Flags().StringP("urlContextRoot", "", "",
+		"define additional URL context root path to be considered in hypermedia links,\ncan also be set via environment variable TMC_URLCONTEXTROOT")
 	_ = viper.BindPFlag(config.KeyUrlContextRoot, serveCmd.Flags().Lookup("urlContextRoot"))
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -19,13 +19,15 @@ func init() {
 	RootCmd.AddCommand(serveCmd)
 	serveCmd.Flags().StringP("host", "", "0.0.0.0", "serve with this host name")
 	serveCmd.Flags().StringP("port", "", "8080", "serve with this port")
+	serveCmd.Flags().StringP("contextRoot", "", "", "define additional context root path")
 }
 
 func serve(cmd *cobra.Command, args []string) {
 	host := cmd.Flag("host").Value.String()
 	port := cmd.Flag("port").Value.String()
+	cr := cmd.Flag("contextRoot").Value.String()
 
-	err := cli.Serve(host, port)
+	err := cli.Serve(host, port, cr)
 	if err != nil {
 		cli.Stderrf("serve failed")
 		os.Exit(1)

--- a/internal/app/cli/serve.go
+++ b/internal/app/cli/serve.go
@@ -9,9 +9,9 @@ import (
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/app/http"
 )
 
-func Serve(host, port string, ctxRoot string) error {
+func Serve(host, port string, urlCtxRoot string) error {
 
-	err := validateContextRoot(ctxRoot)
+	err := validateContextRoot(urlCtxRoot)
 	if err != nil {
 		Stderrf(err.Error())
 		return err
@@ -22,7 +22,7 @@ func Serve(host, port string, ctxRoot string) error {
 
 	handler := http.NewTmcHandler(
 		http.TmcHandlerOptions{
-			ContextRoot: ctxRoot,
+			UrlContextRoot: urlCtxRoot,
 		})
 
 	options := http.GorillaServerOptions{
@@ -50,7 +50,7 @@ func validateContextRoot(ctxRoot string) error {
 	vCtxRoot, _ := url.JoinPath("/", ctxRoot)
 	_, err := url.ParseRequestURI(vCtxRoot)
 	if err != nil {
-		return fmt.Errorf("invalid contextRoot: %s", ctxRoot)
+		return fmt.Errorf("invalid urlContextRoot: %s", ctxRoot)
 	}
 	return nil
 }

--- a/internal/app/http/common.go
+++ b/internal/app/http/common.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,6 +27,9 @@ const (
 
 	basePathInventory   = "/inventory"
 	basePathThingModels = "/thing-models"
+
+	ctxRoot         = "contextRoot"
+	ctxRelPathDepth = "relPathDepth"
 )
 
 func HandleJsonResponse(w http.ResponseWriter, r *http.Request, status int, data interface{}) {
@@ -190,9 +194,11 @@ func convertParams(params any) (*FilterParams, *SearchParams) {
 	return &filter, &search
 }
 
-func toInventoryResponse(toc model.TOC) InventoryResponse {
-	meta := mapInventoryMeta(toc)
-	inv := mapInventoryData(toc.Data)
+func toInventoryResponse(ctx context.Context, toc model.TOC) InventoryResponse {
+	mapper := NewMapper(ctx)
+
+	meta := mapper.GetInventoryMeta(toc)
+	inv := mapper.GetInventoryData(toc.Data)
 	resp := InventoryResponse{
 		Meta: &meta,
 		Data: inv,
@@ -201,16 +207,20 @@ func toInventoryResponse(toc model.TOC) InventoryResponse {
 	return resp
 }
 
-func toInventoryEntryResponse(tocEntry model.TOCEntry) InventoryEntryResponse {
-	invEntry := mapInventoryEntry(tocEntry)
+func toInventoryEntryResponse(ctx context.Context, tocEntry model.TOCEntry) InventoryEntryResponse {
+	mapper := NewMapper(ctx)
+
+	invEntry := mapper.GetInventoryEntry(tocEntry)
 	resp := InventoryEntryResponse{
 		Data: invEntry,
 	}
 	return resp
 }
 
-func toInventoryEntryVersionsResponse(tocVersions []model.TOCVersion) InventoryEntryVersionsResponse {
-	invEntryVersions := mapInventoryEntryVersions(tocVersions)
+func toInventoryEntryVersionsResponse(ctx context.Context, tocVersions []model.TOCVersion) InventoryEntryVersionsResponse {
+	mapper := NewMapper(ctx)
+
+	invEntryVersions := mapper.GetInventoryEntryVersions(tocVersions)
 	resp := InventoryEntryVersionsResponse{
 		Data: invEntryVersions,
 	}

--- a/internal/app/http/common.go
+++ b/internal/app/http/common.go
@@ -28,7 +28,7 @@ const (
 	basePathInventory   = "/inventory"
 	basePathThingModels = "/thing-models"
 
-	ctxRoot         = "contextRoot"
+	ctxUrlRoot      = "urlContextRoot"
 	ctxRelPathDepth = "relPathDepth"
 )
 

--- a/internal/app/http/common.go
+++ b/internal/app/http/common.go
@@ -13,17 +13,20 @@ import (
 )
 
 const (
-	error400Title  = "Bad request"
-	error404Title  = "Not found"
+	error400Title  = "Bad Request"
+	error404Title  = "Not Found"
 	error409Title  = "Conflict"
+	error503Title  = "Service Unavailable"
 	error500Title  = "Internal Server Error"
 	error500Detail = "An unhandled error has occurred. Try again later. If it is a bug we already recorded it. Retrying will most likely not help"
 
 	headerContentType         = "Content-Type"
+	headerCacheControl        = "Cache-Control"
 	headerXContentTypeOptions = "X-Content-Type-Options"
 	mimeJSON                  = "application/json"
 	mimeProblemJSON           = "application/problem+json"
 	noSniff                   = "nosniff"
+	noCache                   = "no-cache, no-store, max-age=0, must-revalidate"
 
 	basePathInventory   = "/inventory"
 	basePathThingModels = "/thing-models"
@@ -48,6 +51,12 @@ func HandleByteResponse(w http.ResponseWriter, r *http.Request, status int, mime
 	w.Header().Set(headerContentType, mime)
 	w.WriteHeader(status)
 	_, _ = w.Write(data)
+}
+
+func HandleHealthyResponse(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set(headerCacheControl, noCache)
+	w.WriteHeader(http.StatusNoContent)
+	_, _ = w.Write(nil)
 }
 
 func HandleErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
@@ -120,7 +129,7 @@ func (e *BaseHttpError) Unwrap() error {
 func NewNotFoundError(err error, detail string, args ...any) error {
 	detail = fmt.Sprintf(detail, args...)
 	return &BaseHttpError{
-		Status: 404,
+		Status: http.StatusNotFound,
 		Title:  error404Title,
 		Detail: detail,
 		Err:    err,
@@ -130,8 +139,17 @@ func NewNotFoundError(err error, detail string, args ...any) error {
 func NewBadRequestError(err error, detail string, args ...any) error {
 	detail = fmt.Sprintf(detail, args...)
 	return &BaseHttpError{
-		Status: 400,
+		Status: http.StatusBadRequest,
 		Title:  error400Title,
+		Detail: detail,
+		Err:    err,
+	}
+}
+
+func NewServiceUnavailableError(err error, detail string) error {
+	return &BaseHttpError{
+		Status: http.StatusServiceUnavailable,
+		Title:  error503Title,
 		Detail: detail,
 		Err:    err,
 	}

--- a/internal/app/http/facade.go
+++ b/internal/app/http/facade.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"errors"
 	"sort"
 
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/commands"
@@ -120,4 +121,31 @@ func pushThingModel(file []byte) (*model.TMID, error) {
 	}
 
 	return &tmID, nil
+}
+
+func checkHealth() error {
+	err := checkHealthLive()
+	if err != nil {
+		return err
+	}
+
+	err = checkHealthReady()
+	return err
+}
+
+func checkHealthLive() error {
+	return nil
+}
+
+func checkHealthReady() error {
+	_, err := remotes.Get("")
+	if err != nil {
+		return errors.New("invalid remotes configuration or no default remote found")
+	}
+	return nil
+}
+
+func checkHealthStartup() error {
+	err := checkHealthReady()
+	return err
 }

--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -1,8 +1,10 @@
 package http
 
 import (
+	"context"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 )
@@ -11,6 +13,11 @@ import (
 // //go:generate oapi-codegen -package http -generate gorilla-server -o server.gen.go ../../../api/tm-catalog.openapi.yaml
 
 type TmcHandler struct {
+	Options TmcHandlerOptions
+}
+
+type TmcHandlerOptions struct {
+	ContextRoot string
 }
 
 func NewRouter() *mux.Router {
@@ -23,11 +30,15 @@ func handleNoRoute(w http.ResponseWriter, r *http.Request) {
 	HandleErrorResponse(w, r, NewNotFoundError(nil, "Path not handled by Thing Model Catalog"))
 }
 
-func NewTmcHandler() *TmcHandler {
-	return &TmcHandler{}
+func NewTmcHandler(options TmcHandlerOptions) *TmcHandler {
+	return &TmcHandler{
+		Options: options,
+	}
 }
 
 func (h *TmcHandler) GetInventory(w http.ResponseWriter, r *http.Request, params GetInventoryParams) {
+	ctx := h.createContext(r)
+
 	filterParams, searchParams := convertParams(params)
 
 	toc, err := listToc(filterParams, searchParams)
@@ -37,13 +48,14 @@ func (h *TmcHandler) GetInventory(w http.ResponseWriter, r *http.Request, params
 		return
 	}
 
-	resp := toInventoryResponse(*toc)
+	resp := toInventoryResponse(ctx, *toc)
 	HandleJsonResponse(w, r, http.StatusOK, resp)
 }
 
 // GetInventoryByName Get an inventory entry by inventory name
 // (GET /inventory/{name})
 func (h *TmcHandler) GetInventoryByName(w http.ResponseWriter, r *http.Request, name string) {
+	ctx := h.createContext(r)
 
 	tocEntry, err := findTocEntry(name)
 
@@ -52,13 +64,15 @@ func (h *TmcHandler) GetInventoryByName(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	resp := toInventoryEntryResponse(*tocEntry)
+	resp := toInventoryEntryResponse(ctx, *tocEntry)
 	HandleJsonResponse(w, r, http.StatusOK, resp)
 }
 
 // GetInventoryVersionsById Get the versions of an inventory entry
 // (GET /inventory/{inventoryId}/versions)
 func (h *TmcHandler) GetInventoryVersionsByName(w http.ResponseWriter, r *http.Request, name string) {
+	ctx := h.createContext(r)
+
 	tocEntry, err := findTocEntry(name)
 
 	if err != nil {
@@ -66,7 +80,7 @@ func (h *TmcHandler) GetInventoryVersionsByName(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	resp := toInventoryEntryVersionsResponse(tocEntry.Versions)
+	resp := toInventoryEntryVersionsResponse(ctx, tocEntry.Versions)
 	HandleJsonResponse(w, r, http.StatusOK, resp)
 }
 
@@ -155,4 +169,28 @@ func (h *TmcHandler) GetMpns(w http.ResponseWriter, r *http.Request, params GetM
 
 	resp := toMpnsResponse(mpns)
 	HandleJsonResponse(w, r, http.StatusOK, resp)
+}
+
+func (h *TmcHandler) createContext(r *http.Request) context.Context {
+	relPathDepth := getRelativeDepth(r.URL.Path, basePathInventory)
+
+	ctx := r.Context()
+	ctx = context.WithValue(ctx, ctxRelPathDepth, relPathDepth)
+	ctx = context.WithValue(ctx, ctxRoot, h.Options.ContextRoot)
+
+	return ctx
+}
+
+func getRelativeDepth(path, siblingPath string) int {
+	path = strings.TrimPrefix(path, "/")
+	siblingPath = strings.TrimPrefix(siblingPath, "/")
+
+	idx := strings.Index(path, siblingPath)
+	if idx < 0 {
+		return 0
+	}
+
+	path = path[idx:]
+	d := strings.Count(path, "/") + 1
+	return d
 }

--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -17,7 +17,7 @@ type TmcHandler struct {
 }
 
 type TmcHandlerOptions struct {
-	ContextRoot string
+	UrlContextRoot string
 }
 
 func NewRouter() *mux.Router {
@@ -176,7 +176,7 @@ func (h *TmcHandler) createContext(r *http.Request) context.Context {
 
 	ctx := r.Context()
 	ctx = context.WithValue(ctx, ctxRelPathDepth, relPathDepth)
-	ctx = context.WithValue(ctx, ctxRoot, h.Options.ContextRoot)
+	ctx = context.WithValue(ctx, ctxUrlRoot, h.Options.UrlContextRoot)
 
 	return ctx
 }

--- a/internal/app/http/mapping.go
+++ b/internal/app/http/mapping.go
@@ -87,7 +87,7 @@ func (m *Mapper) GetInventoryEntryVersion(tocVersion model.TOCVersion) Inventory
 
 func resolveRelativeLink(ctx context.Context, link string) string {
 	link, _ = strings.CutPrefix(link, "/")
-	basePath := ctx.Value(ctxRoot).(string)
+	basePath := ctx.Value(ctxUrlRoot).(string)
 
 	if basePath != "" {
 		link, _ = url.JoinPath("/", basePath, link)

--- a/internal/app/http/mapping.go
+++ b/internal/app/http/mapping.go
@@ -1,36 +1,49 @@
 package http
 
 import (
+	"context"
 	"net/url"
+	"strings"
 
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/model"
 )
 
-func mapInventoryMeta(toc model.TOC) Meta {
+type Mapper struct {
+	Ctx context.Context
+}
+
+func NewMapper(ctx context.Context) *Mapper {
+	return &Mapper{
+		Ctx: ctx,
+	}
+}
+
+func (m *Mapper) GetInventoryMeta(toc model.TOC) Meta {
 	meta := Meta{
 		Created: toc.Meta.Created,
 	}
 	return meta
 }
 
-func mapInventoryData(tocData []*model.TOCEntry) []InventoryEntry {
+func (m *Mapper) GetInventoryData(tocData []*model.TOCEntry) []InventoryEntry {
 	data := []InventoryEntry{}
 	for _, v := range tocData {
-		data = append(data, mapInventoryEntry(*v))
+		data = append(data, m.GetInventoryEntry(*v))
 	}
 
 	return data
 }
 
-func mapInventoryEntry(tocEntry model.TOCEntry) InventoryEntry {
+func (m *Mapper) GetInventoryEntry(tocEntry model.TOCEntry) InventoryEntry {
 	invEntry := InventoryEntry{}
 	invEntry.Name = tocEntry.Name
 	invEntry.SchemaAuthor.SchemaName = tocEntry.Author.Name
 	invEntry.SchemaManufacturer.SchemaName = tocEntry.Manufacturer.Name
 	invEntry.SchemaMpn = tocEntry.Mpn
-	invEntry.Versions = mapInventoryEntryVersions(tocEntry.Versions)
+	invEntry.Versions = m.GetInventoryEntryVersions(tocEntry.Versions)
 
 	hrefSelf, _ := url.JoinPath(basePathInventory, tocEntry.Name)
+	hrefSelf = resolveRelativeLink(m.Ctx, hrefSelf)
 	links := InventoryEntryLinks{
 		Self: hrefSelf,
 	}
@@ -40,17 +53,17 @@ func mapInventoryEntry(tocEntry model.TOCEntry) InventoryEntry {
 	return invEntry
 }
 
-func mapInventoryEntryVersions(tocVersions []model.TOCVersion) []InventoryEntryVersion {
+func (m *Mapper) GetInventoryEntryVersions(tocVersions []model.TOCVersion) []InventoryEntryVersion {
 	invVersions := []InventoryEntryVersion{}
 	for _, v := range tocVersions {
-		invVersion := mapInventoryEntryVersion(v)
+		invVersion := m.GetInventoryEntryVersion(v)
 		invVersions = append(invVersions, invVersion)
 	}
 
 	return invVersions
 }
 
-func mapInventoryEntryVersion(tocVersion model.TOCVersion) InventoryEntryVersion {
+func (m *Mapper) GetInventoryEntryVersion(tocVersion model.TOCVersion) InventoryEntryVersion {
 	invVersion := InventoryEntryVersion{}
 
 	invVersion.TmID = tocVersion.TMID
@@ -61,6 +74,8 @@ func mapInventoryEntryVersion(tocVersion model.TOCVersion) InventoryEntryVersion
 	invVersion.Digest = tocVersion.Digest
 
 	hrefContent, _ := url.JoinPath(basePathThingModels, tocVersion.TMID)
+	hrefContent = resolveRelativeLink(m.Ctx, hrefContent)
+
 	links := InventoryEntryVersionLinks{
 		Content: hrefContent,
 	}
@@ -68,4 +83,21 @@ func mapInventoryEntryVersion(tocVersion model.TOCVersion) InventoryEntryVersion
 	invVersion.Links = &links
 
 	return invVersion
+}
+
+func resolveRelativeLink(ctx context.Context, link string) string {
+	link, _ = strings.CutPrefix(link, "/")
+	basePath := ctx.Value(ctxRoot).(string)
+
+	if basePath != "" {
+		link, _ = url.JoinPath("/", basePath, link)
+	} else {
+		relDepth := ctx.Value(ctxRelPathDepth).(int)
+		if relDepth <= 0 {
+			link = "./" + link
+		} else {
+			link = strings.Repeat("../", relDepth) + link
+		}
+	}
+	return link
 }

--- a/internal/app/http/models.gen.go
+++ b/internal/app/http/models.gen.go
@@ -34,12 +34,12 @@ type ErrorResponse struct {
 
 // InventoryEntry defines model for InventoryEntry.
 type InventoryEntry struct {
+	Links              *InventoryEntryLinks    `json:"links,omitempty"`
 	Name               string                  `json:"name"`
 	SchemaAuthor       SchemaAuthor            `json:"schema:author"`
 	SchemaManufacturer SchemaManufacturer      `json:"schema:manufacturer"`
 	SchemaMpn          string                  `json:"schema:mpn"`
 	Versions           []InventoryEntryVersion `json:"versions"`
-	Links              *InventoryEntryLinks    `json:"links,omitempty"`
 }
 
 // InventoryEntryLinks defines model for InventoryEntryLinks.
@@ -55,12 +55,12 @@ type InventoryEntryResponse struct {
 // InventoryEntryVersion defines model for InventoryEntryVersion.
 type InventoryEntryVersion struct {
 	Description string                      `json:"description"`
-	Version     ModelVersion                `json:"version"`
-	Links       *InventoryEntryVersionLinks `json:"links,omitempty"`
-	TmID        string                      `json:"tmID"`
 	Digest      string                      `json:"digest"`
-	Timestamp   string                      `json:"timestamp"`
 	ExternalID  string                      `json:"externalID"`
+	Links       *InventoryEntryVersionLinks `json:"links,omitempty"`
+	Timestamp   string                      `json:"timestamp"`
+	TmID        string                      `json:"tmID"`
+	Version     ModelVersion                `json:"version"`
 }
 
 // InventoryEntryVersionLinks defines model for InventoryEntryVersionLinks.
@@ -124,45 +124,45 @@ type GetAuthorsParams struct {
 	// FilterManufacturer Filters the authors according to whether they have inventory entries
 	// which belong to at least one of the given manufacturers with an exact match.
 	// The filter works additive to other filters.
-	FilterManufacturer *string `form:"filter[manufacturer],omitempty" json:"filter[manufacturer],omitempty"`
+	FilterManufacturer *string `form:"filter.manufacturer,omitempty" json:"filter.manufacturer,omitempty"`
 
 	// FilterMpn Filters the authors according to whether they have inventory entries
 	// which belong to at least one of the given mpn (manufacturer part number) with an exact match.
 	// The filter works additive to other filters.
-	FilterMpn *string `form:"filter[mpn],omitempty" json:"filter[mpn],omitempty"`
+	FilterMpn *string `form:"filter.mpn,omitempty" json:"filter.mpn,omitempty"`
 
 	// FilterExternalID Filters the authors according to whether they have inventory entries
 	// which belong to at least one of the given external ID's with an exact match.
 	// The filter works additive to other filters.
-	FilterExternalID *string `form:"filter[externalID],omitempty" json:"filter[externalID],omitempty"`
+	FilterExternalID *string `form:"filter.externalID,omitempty" json:"filter.externalID,omitempty"`
 
 	// SearchContent Filters the authors according to whether they have inventory entries
 	// where their content matches the given search.
 	// The search works additive to other filters.
-	SearchContent *string `form:"search[content],omitempty" json:"search[content],omitempty"`
+	SearchContent *string `form:"search.content,omitempty" json:"search.content,omitempty"`
 }
 
 // GetInventoryParams defines parameters for GetInventory.
 type GetInventoryParams struct {
 	// FilterAuthor Filters the inventory by one or more authors having exact match.
 	// The filter works additive to other filters.
-	FilterAuthor *string `form:"filter[author],omitempty" json:"filter[author],omitempty"`
+	FilterAuthor *string `form:"filter.author,omitempty" json:"filter.author,omitempty"`
 
 	// FilterManufacturer Filters the inventory by one or more manufacturers having exact match.
 	// The filter works additive to other filters.
-	FilterManufacturer *string `form:"filter[manufacturer],omitempty" json:"filter[manufacturer],omitempty"`
+	FilterManufacturer *string `form:"filter.manufacturer,omitempty" json:"filter.manufacturer,omitempty"`
 
 	// FilterMpn Filters the inventory by one ore more mpn (manufacturer part number) having exact match.
 	// The filter works additive to other filters.
-	FilterMpn *string `form:"filter[mpn],omitempty" json:"filter[mpn],omitempty"`
+	FilterMpn *string `form:"filter.mpn,omitempty" json:"filter.mpn,omitempty"`
 
 	// FilterExternalID Filters the inventory by one or more external ID having exact match.
 	// The filter works additive to other filters.
-	FilterExternalID *string `form:"filter[externalID],omitempty" json:"filter[externalID],omitempty"`
+	FilterExternalID *string `form:"filter.externalID,omitempty" json:"filter.externalID,omitempty"`
 
 	// SearchContent Filters the inventory according to whether the content of the inventory entries matches the given search.
 	// The search works additive to other filters.
-	SearchContent *string `form:"search[content],omitempty" json:"search[content],omitempty"`
+	SearchContent *string `form:"search.content,omitempty" json:"search.content,omitempty"`
 
 	// Sort Sorts the inventory by one or more fields. The sort is applied in the order of the fields.
 	// The sorting is done ascending per field by default. If a field needs to be sorted descending,
@@ -177,42 +177,42 @@ type GetInventoryParamsSort string
 type GetManufacturersParams struct {
 	// FilterAuthor Filters the manufacturers according to whether they belong to at least one of the given authors with an exact match.
 	// The filter works additive to other filters.
-	FilterAuthor *string `form:"filter[author],omitempty" json:"filter[author],omitempty"`
+	FilterAuthor *string `form:"filter.author,omitempty" json:"filter.author,omitempty"`
 
 	// FilterMpn Filters the manufacturers according to whether they have inventory entries
 	// which belong to at least one of the given mpn (manufacturer part number) with an exact match.
 	// The filter works additive to other filters.
-	FilterMpn *string `form:"filter[mpn],omitempty" json:"filter[mpn],omitempty"`
+	FilterMpn *string `form:"filter.mpn,omitempty" json:"filter.mpn,omitempty"`
 
 	// FilterExternalID Filters the manufacturers according to whether they have inventory entries
 	// which belong to at least one of the given external ID's with an exact match.
 	// The filter works additive to other filters.
-	FilterExternalID *string `form:"filter[externalID],omitempty" json:"filter[externalID],omitempty"`
+	FilterExternalID *string `form:"filter.externalID,omitempty" json:"filter.externalID,omitempty"`
 
 	// SearchContent Filters the manufacturers according to whether they have inventory entries
 	// where their content matches the given search.
 	// The search works additive to other filters.
-	SearchContent *string `form:"search[content],omitempty" json:"search[content],omitempty"`
+	SearchContent *string `form:"search.content,omitempty" json:"search.content,omitempty"`
 }
 
 // GetMpnsParams defines parameters for GetMpns.
 type GetMpnsParams struct {
 	// FilterAuthor Filters the mpns according to whether they belong to at least one of the given authors with an exact match.
 	// The filter works additive to other filters.
-	FilterAuthor *string `form:"filter[author],omitempty" json:"filter[author],omitempty"`
+	FilterAuthor *string `form:"filter.author,omitempty" json:"filter.author,omitempty"`
 
 	// FilterManufacturer Filters the mpns according to whether they belong to at least one of the given manufacturers with an exact match.
 	// The filter works additive to other filters.
-	FilterManufacturer *string `form:"filter[manufacturer],omitempty" json:"filter[manufacturer],omitempty"`
+	FilterManufacturer *string `form:"filter.manufacturer,omitempty" json:"filter.manufacturer,omitempty"`
 
 	// FilterExternalID Filters the mpns according to whether their inventory entry
 	// belongs to at least one of the given external ID's with an exact match.
 	// The filter works additive to other filters.
-	FilterExternalID *string `form:"filter[externalID],omitempty" json:"filter[externalID],omitempty"`
+	FilterExternalID *string `form:"filter.externalID,omitempty" json:"filter.externalID,omitempty"`
 
 	// SearchContent Filters the mpns according to whether their inventory entry content matches the given search.
 	// The search works additive to other filters.
-	SearchContent *string `form:"search[content],omitempty" json:"search[content],omitempty"`
+	SearchContent *string `form:"search.content,omitempty" json:"search.content,omitempty"`
 }
 
 // PushThingModelJSONBody defines parameters for PushThingModel.

--- a/internal/app/http/models.gen.go
+++ b/internal/app/http/models.gen.go
@@ -7,10 +7,6 @@ import (
 	"time"
 )
 
-const (
-	Api_keyScopes = "api_key.Scopes"
-)
-
 // Defines values for GetInventoryParamsSort.
 const (
 	Author       GetInventoryParamsSort = "author"
@@ -34,12 +30,12 @@ type ErrorResponse struct {
 
 // InventoryEntry defines model for InventoryEntry.
 type InventoryEntry struct {
-	Links              *InventoryEntryLinks    `json:"links,omitempty"`
 	Name               string                  `json:"name"`
 	SchemaAuthor       SchemaAuthor            `json:"schema:author"`
 	SchemaManufacturer SchemaManufacturer      `json:"schema:manufacturer"`
 	SchemaMpn          string                  `json:"schema:mpn"`
 	Versions           []InventoryEntryVersion `json:"versions"`
+	Links              *InventoryEntryLinks    `json:"links,omitempty"`
 }
 
 // InventoryEntryLinks defines model for InventoryEntryLinks.
@@ -55,12 +51,12 @@ type InventoryEntryResponse struct {
 // InventoryEntryVersion defines model for InventoryEntryVersion.
 type InventoryEntryVersion struct {
 	Description string                      `json:"description"`
-	Digest      string                      `json:"digest"`
-	ExternalID  string                      `json:"externalID"`
-	Links       *InventoryEntryVersionLinks `json:"links,omitempty"`
-	Timestamp   string                      `json:"timestamp"`
-	TmID        string                      `json:"tmID"`
 	Version     ModelVersion                `json:"version"`
+	Links       *InventoryEntryVersionLinks `json:"links,omitempty"`
+	TmID        string                      `json:"tmID"`
+	Digest      string                      `json:"digest"`
+	Timestamp   string                      `json:"timestamp"`
+	ExternalID  string                      `json:"externalID"`
 }
 
 // InventoryEntryVersionLinks defines model for InventoryEntryVersionLinks.

--- a/internal/app/http/server.gen.go
+++ b/internal/app/http/server.gen.go
@@ -60,35 +60,35 @@ func (siw *ServerInterfaceWrapper) GetAuthors(w http.ResponseWriter, r *http.Req
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetAuthorsParams
 
-	// ------------- Optional query parameter "filter[manufacturer]" -------------
+	// ------------- Optional query parameter "filter.manufacturer" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[manufacturer]", r.URL.Query(), &params.FilterManufacturer)
+	err = runtime.BindQueryParameter("form", true, false, "filter.manufacturer", r.URL.Query(), &params.FilterManufacturer)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[manufacturer]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.manufacturer", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "filter[mpn]" -------------
+	// ------------- Optional query parameter "filter.mpn" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[mpn]", r.URL.Query(), &params.FilterMpn)
+	err = runtime.BindQueryParameter("form", true, false, "filter.mpn", r.URL.Query(), &params.FilterMpn)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[mpn]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.mpn", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "filter[externalID]" -------------
+	// ------------- Optional query parameter "filter.externalID" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[externalID]", r.URL.Query(), &params.FilterExternalID)
+	err = runtime.BindQueryParameter("form", true, false, "filter.externalID", r.URL.Query(), &params.FilterExternalID)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[externalID]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.externalID", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "search[content]" -------------
+	// ------------- Optional query parameter "search.content" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "search[content]", r.URL.Query(), &params.SearchContent)
+	err = runtime.BindQueryParameter("form", true, false, "search.content", r.URL.Query(), &params.SearchContent)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "search[content]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "search.content", Err: err})
 		return
 	}
 
@@ -114,43 +114,43 @@ func (siw *ServerInterfaceWrapper) GetInventory(w http.ResponseWriter, r *http.R
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetInventoryParams
 
-	// ------------- Optional query parameter "filter[author]" -------------
+	// ------------- Optional query parameter "filter.author" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[author]", r.URL.Query(), &params.FilterAuthor)
+	err = runtime.BindQueryParameter("form", true, false, "filter.author", r.URL.Query(), &params.FilterAuthor)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[author]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.author", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "filter[manufacturer]" -------------
+	// ------------- Optional query parameter "filter.manufacturer" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[manufacturer]", r.URL.Query(), &params.FilterManufacturer)
+	err = runtime.BindQueryParameter("form", true, false, "filter.manufacturer", r.URL.Query(), &params.FilterManufacturer)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[manufacturer]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.manufacturer", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "filter[mpn]" -------------
+	// ------------- Optional query parameter "filter.mpn" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[mpn]", r.URL.Query(), &params.FilterMpn)
+	err = runtime.BindQueryParameter("form", true, false, "filter.mpn", r.URL.Query(), &params.FilterMpn)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[mpn]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.mpn", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "filter[externalID]" -------------
+	// ------------- Optional query parameter "filter.externalID" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[externalID]", r.URL.Query(), &params.FilterExternalID)
+	err = runtime.BindQueryParameter("form", true, false, "filter.externalID", r.URL.Query(), &params.FilterExternalID)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[externalID]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.externalID", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "search[content]" -------------
+	// ------------- Optional query parameter "search.content" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "search[content]", r.URL.Query(), &params.SearchContent)
+	err = runtime.BindQueryParameter("form", true, false, "search.content", r.URL.Query(), &params.SearchContent)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "search[content]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "search.content", Err: err})
 		return
 	}
 
@@ -240,35 +240,35 @@ func (siw *ServerInterfaceWrapper) GetManufacturers(w http.ResponseWriter, r *ht
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetManufacturersParams
 
-	// ------------- Optional query parameter "filter[author]" -------------
+	// ------------- Optional query parameter "filter.author" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[author]", r.URL.Query(), &params.FilterAuthor)
+	err = runtime.BindQueryParameter("form", true, false, "filter.author", r.URL.Query(), &params.FilterAuthor)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[author]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.author", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "filter[mpn]" -------------
+	// ------------- Optional query parameter "filter.mpn" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[mpn]", r.URL.Query(), &params.FilterMpn)
+	err = runtime.BindQueryParameter("form", true, false, "filter.mpn", r.URL.Query(), &params.FilterMpn)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[mpn]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.mpn", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "filter[externalID]" -------------
+	// ------------- Optional query parameter "filter.externalID" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[externalID]", r.URL.Query(), &params.FilterExternalID)
+	err = runtime.BindQueryParameter("form", true, false, "filter.externalID", r.URL.Query(), &params.FilterExternalID)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[externalID]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.externalID", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "search[content]" -------------
+	// ------------- Optional query parameter "search.content" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "search[content]", r.URL.Query(), &params.SearchContent)
+	err = runtime.BindQueryParameter("form", true, false, "search.content", r.URL.Query(), &params.SearchContent)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "search[content]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "search.content", Err: err})
 		return
 	}
 
@@ -294,35 +294,35 @@ func (siw *ServerInterfaceWrapper) GetMpns(w http.ResponseWriter, r *http.Reques
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetMpnsParams
 
-	// ------------- Optional query parameter "filter[author]" -------------
+	// ------------- Optional query parameter "filter.author" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[author]", r.URL.Query(), &params.FilterAuthor)
+	err = runtime.BindQueryParameter("form", true, false, "filter.author", r.URL.Query(), &params.FilterAuthor)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[author]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.author", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "filter[manufacturer]" -------------
+	// ------------- Optional query parameter "filter.manufacturer" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[manufacturer]", r.URL.Query(), &params.FilterManufacturer)
+	err = runtime.BindQueryParameter("form", true, false, "filter.manufacturer", r.URL.Query(), &params.FilterManufacturer)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[manufacturer]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.manufacturer", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "filter[externalID]" -------------
+	// ------------- Optional query parameter "filter.externalID" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "filter[externalID]", r.URL.Query(), &params.FilterExternalID)
+	err = runtime.BindQueryParameter("form", true, false, "filter.externalID", r.URL.Query(), &params.FilterExternalID)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter[externalID]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter.externalID", Err: err})
 		return
 	}
 
-	// ------------- Optional query parameter "search[content]" -------------
+	// ------------- Optional query parameter "search.content" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "search[content]", r.URL.Query(), &params.SearchContent)
+	err = runtime.BindQueryParameter("form", true, false, "search.content", r.URL.Query(), &params.SearchContent)
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "search[content]", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "search.content", Err: err})
 		return
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	KeyLog         = "log"
-	KeyLogLevel    = "logLevel"
-	KeyContextRoot = "contextRoot"
-	EnvPrefix      = "tmc"
+	KeyLog            = "log"
+	KeyLogLevel       = "logLevel"
+	KeyUrlContextRoot = "urlContextRoot"
+	EnvPrefix         = "tmc"
 )
 
 var HomeDir string
@@ -58,8 +58,8 @@ func InitViper() {
 	viper.SetEnvPrefix(EnvPrefix)
 	// bind viper variable "log" to env (TMC_LOG)
 	_ = viper.BindEnv(KeyLog)
-	// bind viper variable "contextRoot" to env (TMC_CONTEXTROOT)
-	_ = viper.BindEnv(KeyContextRoot)
+	// bind viper variable "urlContextRoot" to env (TMC_URLCONTEXTROOT)
+	_ = viper.BindEnv(KeyUrlContextRoot)
 
 	viper.WatchConfig()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	KeyLog      = "log"
-	KeyLogLevel = "logLevel"
-	EnvPrefix   = "tmc"
+	KeyLog         = "log"
+	KeyLogLevel    = "logLevel"
+	KeyContextRoot = "contextRoot"
+	EnvPrefix      = "tmc"
 )
 
 var HomeDir string
@@ -55,8 +56,10 @@ func InitViper() {
 	// set prefix "tmc" for environment variables
 	// the environment variables then have to match pattern "tmc_<viper variable>", lower or uppercase
 	viper.SetEnvPrefix(EnvPrefix)
-	// bind viper variable "log" to env (tmc_log or TMC_LOG)
+	// bind viper variable "log" to env (TMC_LOG)
 	_ = viper.BindEnv(KeyLog)
+	// bind viper variable "contextRoot" to env (TMC_CONTEXTROOT)
+	_ = viper.BindEnv(KeyContextRoot)
 
 	viper.WatchConfig()
 }


### PR DESCRIPTION
Changes:

+ renamed all request parameters filter[xxx] to filter.xxx
+ renamed request parameter search[content] to search.content
+ added health endpoints
   + `/healthz`
   + `/healthz/live`
   + `/healthz/ready`
   + `/healthz/startup`
+ fixed proplem with hypermedia relative links
    + if flag `--urlContextRoot` is used on `serve` command (or provided via environment variable `TMC_CONTEXTROOT`),  
       the hypermedia links are absolute to the base and prefixed with the given content root
       Example:
       ```
       export TMC_CONTEXTROOT=/foo/bar
       ./tm-catalog-cli serve
       
       would result in hypermedialinks like
       
       "links": {
           "content":  "/foo/bar/thingmodels/..."
       }       
       ```
    + if neither environment variable `TMC_CONTEXTROOT` nor flag  `--urlContextRoot`  is set,   
       the hypermedia links are relative to the current path
       
       Example:
       ```
         ./tm-catalog-cli serve
         
           would result in hypermedialinks like
       
         "links": {
             "content":  "../thingmodels/..."
         }       
       
       ```