### PR TITLE
fix: adjust urls for embedded schemas to prevent misleading error messages on validation

### DIFF
--- a/internal/commands/validate/tmc-mandatory.schema.json
+++ b/internal/commands/validate/tmc-mandatory.schema.json
@@ -1,7 +1,6 @@
 {
   "description": "JSON Schema for validating Thing Models for importing into Thing Model Catalog",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "tm-mandatory.schema.json",
   "definitions": {
     "context": {
       "type": "array",

--- a/internal/commands/validate/validate.go
+++ b/internal/commands/validate/validate.go
@@ -26,9 +26,9 @@ var tmValidator *jsonschema.Schema
 var modbusValidator *jsonschema.Schema
 
 const (
-	tmcMandatorySchemaUrl = "tmc-mandatory.schema.json"
+	tmcMandatorySchemaUrl = "resource://tmc-mandatory.schema.json"
 	tmSchemaUrl           = "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/tm-json-schema-validation.json"
-	modbusSchemaUrl       = "modbus.schema.json"
+	modbusSchemaUrl       = "resource://modbus.schema.json"
 )
 
 func init() {


### PR DESCRIPTION
- fix: adjust urls for embedded schemas to prevent misleading error messages on validation

This PR addresses the comment https://github.com/web-of-things-open-source/tm-catalog-cli/issues/1#issuecomment-1836042447
