### PR TITLE
feat: enable using a directory as an ad-hoc TM repository

### DIFF
--- a/cmd/create-toc.go
+++ b/cmd/create-toc.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -11,25 +12,33 @@ import (
 )
 
 var createTOCCmd = &cobra.Command{
-	Use:   "create-toc DIRECTORY [--remote <remoteName>]",
+	Use:   "create-toc",
 	Short: "Creates a Table of Contents",
-	Long: `Creates a Table of Contents listing all paths to Thing Model files. Used for simple search functionality.
---remote is optional if there's only one remote configured`,
+	Long: `Creates a Table of Contents file listing all paths to Thing Model files. Used for simple search functionality.
+Specifying the repository with --directory or --remote is optional if there's exactly one remote configured`,
 	Run: executeCreateTOC,
 }
 
 func init() {
 	RootCmd.AddCommand(createTOCCmd)
 	createTOCCmd.Flags().StringP("remote", "r", "", "name of the remote")
+	createTOCCmd.Flags().StringP("directory", "d", "", "TM repository directory")
+
 }
 
 func executeCreateTOC(cmd *cobra.Command, args []string) {
 	var log = slog.Default()
 
 	remoteName := cmd.Flag("remote").Value.String()
-	log.Debug(fmt.Sprintf("creating table of contents for remote %s", remoteName))
+	dir := cmd.Flag("directory").Value.String()
+	spec, err := remotes.NewSpec(remoteName, dir)
+	if errors.Is(err, remotes.ErrInvalidSpec) {
+		cli.Stderrf("Invalid specification of target repository. --remote and --directory are mutually exclusive. Set at most one")
+		os.Exit(1)
+	}
+	log.Debug(fmt.Sprintf("creating table of contents for remote %s", spec))
 
-	remote, err := remotes.DefaultManager().Get(remoteName)
+	remote, err := remotes.DefaultManager().Get(spec)
 	if err != nil {
 		//TODO: log to stderr or logger ?
 		cli.Stderrf("could not initialize a remote instance for %s: %v. check config", remoteName, err)

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -11,9 +12,8 @@ import (
 var fetchCmd = &cobra.Command{
 	Use:   "fetch (<NAME[:SEMVER|DIGEST]> | <TMID>) [--remote <remoteName>] [--output <filename>] [--with-path]",
 	Short: "Fetches the TM by name or id",
-	Long: `Fetches TM by name, optionally accepting semantic version or digest. 
---remote, -r
-	The name of the remote repository is optional if there's only one remote configured
+	Long: `Fetches TM by name, optionally accepting semantic version or digest.
+
 --output, -o
 	Write output to a file instead of stdout. If <filename> is an existing folder, the content will be written into
 	a file in that folder. If it's a file or no such file exists, the output is written into a file with given name
@@ -26,19 +26,27 @@ var fetchCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(fetchCmd)
 	fetchCmd.Flags().StringP("remote", "r", "", "name of the remote to fetch from")
+	fetchCmd.Flags().StringP("directory", "d", "", "TM repository directory")
 	fetchCmd.Flags().StringP("output", "o", "", "write output to a file instead of stdout")
 	fetchCmd.Flags().BoolP("with-path", "", false, "create folder structure under output")
 }
 
 func executeFetch(cmd *cobra.Command, args []string) {
 	remoteName := cmd.Flag("remote").Value.String()
+	dirName := cmd.Flag("directory").Value.String()
 	outputFile := cmd.Flag("output").Value.String()
 	withPath, err := cmd.Flags().GetBool("with-path")
 	if err != nil {
 		cli.Stderrf("invalid --with-path flag")
 		os.Exit(1)
 	}
-	err = cli.NewFetchExecutor(remotes.DefaultManager()).Fetch(remoteName, args[0], outputFile, withPath)
+	spec, err := remotes.NewSpec(remoteName, dirName)
+	if errors.Is(err, remotes.ErrInvalidSpec) {
+		cli.Stderrf("Invalid specification of target repository. --remote and --directory are mutually exclusive. Set at most one")
+		os.Exit(1)
+	}
+
+	err = cli.NewFetchExecutor(remotes.DefaultManager()).Fetch(spec, args[0], outputFile, withPath)
 	if err != nil {
 		cli.Stderrf("fetch failed")
 		os.Exit(1)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -24,7 +24,7 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List TMs in catalog",
 	Long:  `List TMs and optionally filter them`,
-	Args:  cobra.MaximumNArgs(1),
+	Args:  cobra.ExactArgs(0),
 	Run:   executeList,
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,16 +1,18 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/app/cli"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal/remotes"
 )
 
 var listCmd = &cobra.Command{
-	Use:   "list [PATTERN] [--remote <remoteName>]",
+	Use:   "list [PATTERN]",
 	Short: "List TMs in catalog",
-	Long:  `List TMs and filter for PATTERN in all mandatory fields. --remote is optional if there's only one remote configured`,
+	Long:  `List TMs and filter for PATTERN in all mandatory fields`,
 	Args:  cobra.MaximumNArgs(1),
 	Run:   executeList,
 }
@@ -18,17 +20,24 @@ var listCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(listCmd)
 	listCmd.Flags().StringP("remote", "r", "", "name of the remote to list")
+	listCmd.Flags().StringP("directory", "d", "", "TM repository directory to list")
 }
 
 func executeList(cmd *cobra.Command, args []string) {
 	remoteName := cmd.Flag("remote").Value.String()
+	dirName := cmd.Flag("directory").Value.String()
 
 	filter := ""
 	if len(args) > 0 {
 		filter = args[0]
 	}
+	spec, err := remotes.NewSpec(remoteName, dirName)
+	if errors.Is(err, remotes.ErrInvalidSpec) {
+		cli.Stderrf("Invalid specification of target repository. --remote and --directory are mutually exclusive. Set at most one")
+		os.Exit(1)
+	}
 
-	err := cli.List(remoteName, filter)
+	err = cli.List(spec, filter)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -19,8 +20,7 @@ file-or-dirname
 	The name of the file or directory to push. Pushing a directory will walk the directory tree recursively and 
 	import all found ThingModels.
 
---remote, -r
-	Name of the target remote repository. Can be omitted if there's only one configured
+Specifying the repository with --directory or --remote is optional if there's exactly one remote configured
 
 --opt-path, -p
 	Appends optional path parts to the target path (and id) of imported files, after the mandatory path structure.
@@ -37,15 +37,23 @@ file-or-dirname
 func init() {
 	RootCmd.AddCommand(pushCmd)
 	pushCmd.Flags().StringP("remote", "r", "", "the target remote. can be omitted if there's only one")
+	pushCmd.Flags().StringP("directory", "d", "", "TM repository directory")
 	pushCmd.Flags().StringP("opt-path", "p", "", "append optional path to mandatory target directory structure")
 	pushCmd.Flags().BoolP("opt-tree", "t", false, "use original directory tree as optional path for each file. Has no effect with a single file. Overrides -p")
 }
 
 func executePush(cmd *cobra.Command, args []string) {
 	remoteName := cmd.Flag("remote").Value.String()
+	dirName := cmd.Flag("directory").Value.String()
 	optPath := cmd.Flag("opt-path").Value.String()
 	optTree, _ := cmd.Flags().GetBool("opt-tree")
-	results, err := cli.NewPushExecutor(remotes.DefaultManager(), time.Now).Push(args[0], remoteName, optPath, optTree)
+	spec, err := remotes.NewSpec(remoteName, dirName)
+	if errors.Is(err, remotes.ErrInvalidSpec) {
+		cli.Stderrf("Invalid specification of target repository. --remote and --directory are mutually exclusive. Set at most one")
+		os.Exit(1)
+	}
+
+	results, err := cli.NewPushExecutor(remotes.DefaultManager(), time.Now).Push(args[0], spec, optPath, optTree)
 	for _, res := range results {
 		fmt.Println(res)
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,20 +1,23 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 
 	"github.com/spf13/viper"
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/config"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal/remotes"
 
 	"github.com/spf13/cobra"
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/app/cli"
 )
 
 var serveCmd = &cobra.Command{
-	Use:   "serve [--remote <remote-name>]",
+	Use:   "serve",
 	Short: "Serve TMs in catalog",
 	Long: `Serve TMs in catalog.
-If there are multiple remotes configured, --remote flag must be specified to define the target remote for push operations`,
+A target for push operations must be specified with either --directory or --remote.
+This may be omitted if there's exactly one remote configured`,
 	Args: cobra.MaximumNArgs(0),
 	Run:  serve,
 }
@@ -24,6 +27,7 @@ func init() {
 	serveCmd.Flags().StringP("host", "", "0.0.0.0", "serve with this host name")
 	serveCmd.Flags().StringP("port", "", "8080", "serve with this port")
 	serveCmd.Flags().StringP("remote", "r", "", "name of the remote target for push")
+	serveCmd.Flags().StringP("directory", "d", "", "TM repository directory for push")
 	serveCmd.Flags().StringP("urlContextRoot", "", "",
 		"define additional URL context root path to be considered in hypermedia links,\ncan also be set via environment variable TMC_URLCONTEXTROOT")
 	_ = viper.BindPFlag(config.KeyUrlContextRoot, serveCmd.Flags().Lookup("urlContextRoot"))
@@ -33,9 +37,16 @@ func serve(cmd *cobra.Command, args []string) {
 	host := cmd.Flag("host").Value.String()
 	port := cmd.Flag("port").Value.String()
 	remote := cmd.Flag("remote").Value.String()
+	dir := cmd.Flag("directory").Value.String()
+	spec, err := remotes.NewSpec(remote, dir)
+	if errors.Is(err, remotes.ErrInvalidSpec) {
+		cli.Stderrf("Invalid specification of target repository. --remote and --directory are mutually exclusive. Set at most one")
+		os.Exit(1)
+	}
+
 	urlCtxRoot := viper.GetString(config.KeyUrlContextRoot)
 
-	err := cli.Serve(host, port, urlCtxRoot, remote)
+	err = cli.Serve(host, port, urlCtxRoot, spec)
 	if err != nil {
 		cli.Stderrf("serve failed")
 		os.Exit(1)

--- a/internal/app/cli/fetch.go
+++ b/internal/app/cli/fetch.go
@@ -21,13 +21,13 @@ func NewFetchExecutor(rm remotes.RemoteManager) *FetchExecutor {
 	}
 }
 
-func (e *FetchExecutor) Fetch(remoteName, idOrName, outputFile string, withPath bool) error {
+func (e *FetchExecutor) Fetch(remote remotes.RepoSpec, idOrName, outputFile string, withPath bool) error {
 	if withPath && len(outputFile) == 0 {
 		Stderrf("--with-path requires non-empty --output")
 		return errors.New("--output not provided")
 	}
 
-	id, thing, err := commands.NewFetchCommand(e.rm).FetchByTMIDOrName(remoteName, idOrName)
+	id, thing, err := commands.NewFetchCommand(e.rm).FetchByTMIDOrName(remote, idOrName)
 	if err != nil {
 		Stderrf("Could not fetch from remote: %v", err)
 		return err

--- a/internal/app/cli/fetch_test.go
+++ b/internal/app/cli/fetch_test.go
@@ -17,7 +17,7 @@ func TestFetchExecutor_Fetch_To_Stdout(t *testing.T) {
 	rm := remotes.NewMockRemoteManager(t)
 	r := remotes.NewMockRemote(t)
 
-	rm.On("Get", "remote").Return(r, nil)
+	rm.On("Get", remotes.NewRemoteSpec("remote")).Return(r, nil)
 	r.On("Fetch", "author/manufacturer/mpn/folder/sub/v1.0.0-20231205123243-c49617d2e4fc.tm.json").
 		Return("author/manufacturer/mpn/folder/sub/v1.0.0-20231205123243-c49617d2e4fc.tm.json", []byte("{}"), nil)
 
@@ -30,7 +30,7 @@ func TestFetchExecutor_Fetch_To_Stdout(t *testing.T) {
 		io.Copy(&buf, rr)
 		outC <- buf.String()
 	}()
-	err := e.Fetch("remote", "author/manufacturer/mpn/folder/sub/v1.0.0-20231205123243-c49617d2e4fc.tm.json",
+	err := e.Fetch(remotes.NewRemoteSpec("remote"), "author/manufacturer/mpn/folder/sub/v1.0.0-20231205123243-c49617d2e4fc.tm.json",
 		"", false)
 	assert.NoError(t, err)
 	os.Stdout = old
@@ -49,31 +49,31 @@ func TestFetchExecutor_Fetch_To_OutputFile(t *testing.T) {
 
 	rm := remotes.NewMockRemoteManager(t)
 	r := remotes.NewMockRemote(t)
-	rm.On("Get", "remote").Return(r, nil)
+	rm.On("Get", remotes.NewRemoteSpec("remote")).Return(r, nil)
 	r.On("Fetch", tmid).Return(aid, tm, nil)
 
 	e := NewFetchExecutor(rm)
-	err = e.Fetch("remote", tmid, "", true)
+	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, "", true)
 
 	fileTxt := filepath.Join(temp, "file.txt")
 	_ = os.WriteFile(fileTxt, []byte("text"), 0660)
-	err = e.Fetch("remote", tmid, fileTxt, true)
+	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, fileTxt, true)
 	assert.Error(t, err)
 
-	err = e.Fetch("remote", tmid, fileTxt, false)
+	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, fileTxt, false)
 	assert.NoError(t, err)
 	file, err := os.ReadFile(fileTxt)
 	assert.NoError(t, err)
 	assert.Equal(t, tm, file)
 
-	err = e.Fetch("remote", tmid, temp, false)
+	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, temp, false)
 	assert.NoError(t, err)
 	assert.FileExists(t, filepath.Join(temp, filepath.Base(aid)))
 	file, err = os.ReadFile(filepath.Join(temp, filepath.Base(aid)))
 	assert.NoError(t, err)
 	assert.Equal(t, tm, file)
 
-	err = e.Fetch("remote", tmid, temp, true)
+	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, temp, true)
 	assert.NoError(t, err)
 	assert.FileExists(t, filepath.Join(temp, aid))
 	file, err = os.ReadFile(filepath.Join(temp, aid))

--- a/internal/app/cli/list.go
+++ b/internal/app/cli/list.go
@@ -15,8 +15,8 @@ import (
 const columnWidthName = "TMC_COLUMNWIDTH"
 const columnWidthDefault = 40
 
-func List(remoteName, filter string) error {
-	toc, err := commands.NewListCommand(remotes.DefaultManager()).List(remoteName, &model.SearchParams{
+func List(remote remotes.RepoSpec, filter string) error {
+	toc, err := commands.NewListCommand(remotes.DefaultManager()).List(remote, &model.SearchParams{
 		Query: filter,
 	})
 	if err != nil {

--- a/internal/app/cli/push.go
+++ b/internal/app/cli/push.go
@@ -57,10 +57,10 @@ func NewPushExecutor(rm remotes.RemoteManager, now commands.Now) *PushExecutor {
 
 // Push pushes file or directory to remote repository
 // Returns the list of push results up to the first encountered error, and the error
-func (p *PushExecutor) Push(filename, remoteName, optPath string, optTree bool) ([]PushResult, error) {
-	remote, err := p.rm.Get(remoteName)
+func (p *PushExecutor) Push(filename string, spec remotes.RepoSpec, optPath string, optTree bool) ([]PushResult, error) {
+	remote, err := p.rm.Get(spec)
 	if err != nil {
-		Stderrf("Could not ìnitialize a remote instance for %s: %v\ncheck config", remoteName, err)
+		Stderrf("Could not ìnitialize a remote instance for %s: %v\ncheck config", spec, err)
 		return nil, err
 	}
 

--- a/internal/app/cli/push_test.go
+++ b/internal/app/cli/push_test.go
@@ -15,7 +15,7 @@ import (
 func TestPushExecutor_Push(t *testing.T) {
 	rm := remotes.NewMockRemoteManager(t)
 	r := remotes.NewMockRemote(t)
-	rm.On("Get", "remote").Return(r, nil)
+	rm.On("Get", remotes.NewRemoteSpec("remote")).Return(r, nil)
 
 	t.Run("push when none exists", func(t *testing.T) {
 
@@ -25,7 +25,7 @@ func TestPushExecutor_Push(t *testing.T) {
 		r.On("Push", tmid, mock.Anything).Return(nil)
 		r.On("CreateToC").Return(nil)
 
-		res, err := e.Push("../../../test/data/push/omnilamp-versioned.json", "remote", "", false)
+		res, err := e.Push("../../../test/data/push/omnilamp-versioned.json", remotes.NewRemoteSpec("remote"), "", false)
 		assert.NoError(t, err)
 		assert.Len(t, res, 1)
 		assert.Equal(t, PushOK, res[0].typ)
@@ -35,7 +35,7 @@ func TestPushExecutor_Push(t *testing.T) {
 
 		now := func() time.Time { return time.Date(2023, time.November, 10, 12, 32, 43, 0, time.UTC) }
 		e := NewPushExecutor(rm, now)
-		_, err := e.Push("does-not-exist.json", "remote", "", false)
+		_, err := e.Push("does-not-exist.json", remotes.NewRemoteSpec("remote"), "", false)
 		assert.Error(t, err)
 	})
 
@@ -48,7 +48,7 @@ func TestPushExecutor_Push(t *testing.T) {
 		}
 		e := NewPushExecutor(rm, now)
 		r.On("Push", tmid2, mock.Anything).Return(&remotes.ErrTMExists{ExistingId: "omnicorp-TM-department/omnicorp/omnilamp/v3.2.1-20231110123243-1e788769a659.tm.json"})
-		res, err := e.Push("../../../test/data/push/omnilamp-versioned.json", "remote", "", false)
+		res, err := e.Push("../../../test/data/push/omnilamp-versioned.json", remotes.NewRemoteSpec("remote"), "", false)
 		assert.NoError(t, err)
 		assert.Len(t, res, 1)
 		assert.Equal(t, TMExists, res[0].typ)
@@ -62,7 +62,7 @@ func TestPushExecutor_Push(t *testing.T) {
 		}
 		e := NewPushExecutor(rm, now)
 		r.On("Push", tmid3, mock.Anything).Return(errors.New("unexpected"))
-		res, err := e.Push("../../../test/data/push/omnilamp-versioned.json", "remote", "", false)
+		res, err := e.Push("../../../test/data/push/omnilamp-versioned.json", remotes.NewRemoteSpec("remote"), "", false)
 		assert.Error(t, err)
 		assert.Len(t, res, 1)
 		assert.Equal(t, PushErr, res[0].typ)
@@ -75,7 +75,7 @@ func TestPushExecutor_Push(t *testing.T) {
 		r.On("Push", tmid, mock.Anything).Return(nil)
 		r.On("CreateToC").Return(nil)
 
-		res, err := e.Push("../../../test/data/push/omnilamp-versioned.json", "remote", "a/b/c", false)
+		res, err := e.Push("../../../test/data/push/omnilamp-versioned.json", remotes.NewRemoteSpec("remote"), "a/b/c", false)
 		assert.NoError(t, err)
 		assert.Len(t, res, 1)
 		assert.Equal(t, PushOK, res[0].typ)
@@ -85,7 +85,7 @@ func TestPushExecutor_Push(t *testing.T) {
 func TestPushExecutor_Push_Directory(t *testing.T) {
 	rm := remotes.NewMockRemoteManager(t)
 	r := remotes.NewMockRemote(t)
-	rm.On("Get", "remote").Return(r, nil)
+	rm.On("Get", remotes.NewRemoteSpec("remote")).Return(r, nil)
 
 	t.Run("push directory", func(t *testing.T) {
 		clk := testutils.NewTestClock(time.Date(2023, time.November, 10, 12, 32, 43, 0, time.UTC), time.Second)
@@ -100,7 +100,7 @@ func TestPushExecutor_Push_Directory(t *testing.T) {
 		r.On("Push", tmid, mock.Anything).Return(&remotes.ErrTMExists{ExistingId: "omnicorp-TM-department/omnicorp/omnilamp/v0.0.0-20231110123244-be839ce9daf1.tm.json"})
 		r.On("CreateToC").Return(nil)
 
-		res, err := e.Push("../../../test/data/push", "remote", "", false)
+		res, err := e.Push("../../../test/data/push", remotes.NewRemoteSpec("remote"), "", false)
 		assert.NoError(t, err)
 		assert.Len(t, res, 4)
 		assert.Equalf(t, PushOK, res[0].typ, "res[0]: want PushOK, got %v", res[0].typ)
@@ -123,7 +123,7 @@ func TestPushExecutor_Push_Directory(t *testing.T) {
 		r.On("Push", tmid, mock.Anything).Return(nil)
 		r.On("CreateToC").Return(nil)
 
-		res, err := e.Push("../../../test/data/push", "remote", "opt", false)
+		res, err := e.Push("../../../test/data/push", remotes.NewRemoteSpec("remote"), "opt", false)
 		assert.NoError(t, err)
 		assert.Len(t, res, 4)
 		for i, r := range res {
@@ -145,7 +145,7 @@ func TestPushExecutor_Push_Directory(t *testing.T) {
 		r.On("Push", tmid, mock.Anything).Return(nil)
 		r.On("CreateToC").Return(nil)
 
-		res, err := e.Push("../../../test/data/push", "remote", "", true)
+		res, err := e.Push("../../../test/data/push", remotes.NewRemoteSpec("remote"), "", true)
 		assert.NoError(t, err)
 		assert.Len(t, res, 4)
 		for i, r := range res {

--- a/internal/app/cli/serve.go
+++ b/internal/app/cli/serve.go
@@ -11,17 +11,17 @@ import (
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/remotes"
 )
 
-func Serve(host, port, urlCtxRoot, remote string) error {
+func Serve(host, port, urlCtxRoot string, spec remotes.RepoSpec) error {
 
 	err := validateContextRoot(urlCtxRoot)
 	if err != nil {
 		Stderrf(err.Error())
 		return err
 	}
-	_, err = remotes.DefaultManager().Get(remote)
+	_, err = remotes.DefaultManager().Get(spec)
 	if err != nil {
 		if errors.Is(err, remotes.ErrAmbiguous) {
-			Stderrf("must specify remote target for push with --remote when there are multiple remotes configured")
+			Stderrf("must specify target for push with --directory or --remote when there are multiple remotes configured")
 		} else {
 			Stderrf(err.Error())
 		}
@@ -34,7 +34,7 @@ func Serve(host, port, urlCtxRoot, remote string) error {
 	handler := http.NewTmcHandler(
 		http.TmcHandlerOptions{
 			UrlContextRoot: urlCtxRoot,
-			PushTarget:     remote,
+			PushTarget:     spec,
 		})
 
 	options := http.GorillaServerOptions{

--- a/internal/app/cli/versions.go
+++ b/internal/app/cli/versions.go
@@ -10,8 +10,8 @@ import (
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/remotes"
 )
 
-func ListVersions(remoteName, name string) error {
-	tocEntry, err := commands.NewVersionsCommand(remotes.DefaultManager()).ListVersions(remoteName, name)
+func ListVersions(spec remotes.RepoSpec, name string) error {
+	tocEntry, err := commands.NewVersionsCommand(remotes.DefaultManager()).ListVersions(spec, name)
 	if err != nil {
 		Stderrf("Could not list versions for %s: %v\ncheck config", name, err)
 		return err
@@ -25,7 +25,7 @@ func printToCThing(name string, tocEntry model.FoundEntry) {
 	//	colWidth := columnWidth()
 	table := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
-	_, _ = fmt.Fprintf(table, "NAME\tVERSION\tDESCRIPTION\tREMOTE\tPATH\n")
+	_, _ = fmt.Fprintf(table, "NAME\tVERSION\tDESCRIPTION\tREPOSITORY\tPATH\n")
 	for _, v := range tocEntry.Versions {
 		_, _ = fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\n", name, v.Version.Model, v.Description, v.FoundIn, v.Links["content"])
 	}

--- a/internal/app/http/facade.go
+++ b/internal/app/http/facade.go
@@ -12,7 +12,7 @@ import (
 
 func listToc(search *model.SearchParams) (*model.SearchResult, error) {
 	c := commands.NewListCommand(remotes.DefaultManager())
-	toc, err := c.List("", search)
+	toc, err := c.List(remotes.EmptySpec, search)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func fetchThingModel(tmID string) ([]byte, error) {
 		return nil, err
 	}
 
-	_, data, err := commands.NewFetchCommand(remotes.DefaultManager()).FetchByTMID("", tmID)
+	_, data, err := commands.NewFetchCommand(remotes.DefaultManager()).FetchByTMID(remotes.EmptySpec, tmID)
 	if errors.Is(err, commands.ErrTmNotFound) {
 		return nil, NewNotFoundError(err, "File does not exist")
 	} else if err != nil {
@@ -88,8 +88,8 @@ func fetchThingModel(tmID string) ([]byte, error) {
 	return data, nil
 }
 
-func pushThingModel(file []byte, remoteName string) (string, error) {
-	remote, err := remotes.DefaultManager().Get(remoteName)
+func pushThingModel(file []byte, spec remotes.RepoSpec) (string, error) {
+	remote, err := remotes.DefaultManager().Get(spec)
 	if err != nil {
 		return "", err
 	}
@@ -120,7 +120,7 @@ func checkHealthLive() error {
 }
 
 func checkHealthReady() error {
-	_, err := remotes.DefaultManager().Get("")
+	_, err := remotes.DefaultManager().Get(remotes.EmptySpec)
 	if err != nil {
 		return errors.New("invalid remotes configuration or no default remote found")
 	}

--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal/remotes"
 )
 
 // Hint: after generating the server code based on the openapi spec
@@ -24,7 +25,7 @@ type TmcHandler struct {
 
 type TmcHandlerOptions struct {
 	UrlContextRoot string
-	PushTarget     string
+	PushTarget     remotes.RepoSpec
 }
 
 func NewRouter() *mux.Router {

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -16,8 +16,8 @@ func NewListCommand(m remotes.RemoteManager) *ListCommand {
 		remoteMgr: m,
 	}
 }
-func (c *ListCommand) List(remoteName string, search *model.SearchParams) (model.SearchResult, error) {
-	rs, err := remotes.GetNamedOrAll(c.remoteMgr, remoteName)
+func (c *ListCommand) List(rSpec remotes.RepoSpec, search *model.SearchParams) (model.SearchResult, error) {
+	rs, err := remotes.GetSpecdOrAll(c.remoteMgr, rSpec)
 	if err != nil {
 		return model.SearchResult{}, err
 	}
@@ -26,7 +26,7 @@ func (c *ListCommand) List(remoteName string, search *model.SearchParams) (model
 	for _, remote := range rs {
 		toc, err := remote.List(search)
 		if err != nil {
-			return model.SearchResult{}, fmt.Errorf("could not list %s: %w", remote.Name(), err)
+			return model.SearchResult{}, fmt.Errorf("could not list %s: %w", remote.Spec(), err)
 		}
 		res.Merge(&toc)
 	}

--- a/internal/commands/list_test.go
+++ b/internal/commands/list_test.go
@@ -47,7 +47,7 @@ func TestListCommand_List(t *testing.T) {
 	}, nil)
 
 	c := NewListCommand(rm)
-	res, err := c.List("", &model.SearchParams{Query: "omnicorp"})
+	res, err := c.List(remotes.EmptySpec, &model.SearchParams{Query: "omnicorp"})
 
 	assert.NoError(t, err)
 	assert.Len(t, res.Entries, 3)

--- a/internal/commands/push_test.go
+++ b/internal/commands/push_test.go
@@ -136,7 +136,7 @@ func TestPushToRemoteUnversioned(t *testing.T) {
 	remote, err := remotes.NewFileRemote(map[string]any{
 		"type": "file",
 		"loc":  root,
-	}, "")
+	}, remotes.EmptySpec)
 	assert.NoError(t, err)
 
 	clk := testutils.NewTestClock(time.Now(), 1050*time.Millisecond)
@@ -198,7 +198,7 @@ func TestPushToRemoteVersioned(t *testing.T) {
 	remote, err := remotes.NewFileRemote(map[string]any{
 		"type": "file",
 		"loc":  root,
-	}, "")
+	}, remotes.EmptySpec)
 	assert.NoError(t, err)
 
 	c := NewPushCommand(time.Now)

--- a/internal/commands/versions.go
+++ b/internal/commands/versions.go
@@ -16,8 +16,8 @@ func NewVersionsCommand(manager remotes.RemoteManager) *VersionsCommand {
 		remoteMgr: manager,
 	}
 }
-func (c *VersionsCommand) ListVersions(remoteName, name string) (model.FoundEntry, error) {
-	rs, err := remotes.GetNamedOrAll(c.remoteMgr, remoteName)
+func (c *VersionsCommand) ListVersions(spec remotes.RepoSpec, name string) (model.FoundEntry, error) {
+	rs, err := remotes.GetSpecdOrAll(c.remoteMgr, spec)
 	if err != nil {
 		return model.FoundEntry{}, err
 	}

--- a/internal/commands/versions_test.go
+++ b/internal/commands/versions_test.go
@@ -24,13 +24,13 @@ func TestVersionsCommand_ListVersions(t *testing.T) {
 					TOCVersion: model.TOCVersion{
 						TMID: "omnicorp/senseall/v0.36.0-20231231153548-243d1b462ccc.tm.json",
 					},
-					FoundIn: "r1",
+					FoundIn: model.FoundSource{RemoteName: "r1"},
 				},
 				{
 					TOCVersion: model.TOCVersion{
 						TMID: "omnicorp/senseall/v0.35.0-20231230153548-243d1b462bbb.tm.json",
 					},
-					FoundIn: "r1",
+					FoundIn: model.FoundSource{RemoteName: "r1"},
 				},
 			},
 		}, nil)
@@ -45,34 +45,34 @@ func TestVersionsCommand_ListVersions(t *testing.T) {
 				TOCVersion: model.TOCVersion{
 					TMID: "omnicorp/senseall/v0.34.0-20231130153548-243d1b462aaa.tm.json",
 				},
-				FoundIn: "r2",
+				FoundIn: model.FoundSource{RemoteName: "r2"},
 			},
 			{
 				TOCVersion: model.TOCVersion{
 					TMID: "omnicorp/senseall/v0.35.0-20231230173548-243d1b462bbb.tm.json",
 				},
-				FoundIn: "r2",
+				FoundIn: model.FoundSource{RemoteName: "r2"},
 			},
 		},
 	}, nil)
 
 	c := NewVersionsCommand(rm)
-	res, err := c.ListVersions("", "senseall")
+	res, err := c.ListVersions(remotes.EmptySpec, "senseall")
 
 	assert.NoError(t, err)
 	assert.Len(t, res.Versions, 3)
 	assert.Equal(t, []model.FoundVersion{
 		{
 			TOCVersion: model.TOCVersion{TMID: "omnicorp/senseall/v0.34.0-20231130153548-243d1b462aaa.tm.json"},
-			FoundIn:    "r2",
+			FoundIn:    model.FoundSource{RemoteName: "r2"},
 		},
 		{
 			TOCVersion: model.TOCVersion{TMID: "omnicorp/senseall/v0.35.0-20231230173548-243d1b462bbb.tm.json"},
-			FoundIn:    "r2",
+			FoundIn:    model.FoundSource{RemoteName: "r2"},
 		},
 		{
 			TOCVersion: model.TOCVersion{TMID: "omnicorp/senseall/v0.36.0-20231231153548-243d1b462ccc.tm.json"},
-			FoundIn:    "r1",
+			FoundIn:    model.FoundSource{RemoteName: "r1"},
 		},
 	}, res.Versions)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,12 +30,6 @@ func InitConfig() {
 func InitViper() {
 	viper.SetDefault(KeyLog, false)
 	viper.SetDefault(KeyLogLevel, "INFO")
-	viper.SetDefault("remotes", map[string]any{
-		"local": map[string]any{
-			"type": "file",
-			"loc":  "~/tm-catalog",
-		},
-	})
 
 	viper.SetConfigType("json")
 	viper.SetConfigName("config")

--- a/internal/model/search.go
+++ b/internal/model/search.go
@@ -17,10 +17,22 @@ type FoundEntry struct {
 }
 type FoundVersion struct {
 	TOCVersion
-	FoundIn string
+	FoundIn FoundSource
 }
 
-func NewSearchResultFromTOC(toc TOC, foundIn string) SearchResult {
+type FoundSource struct {
+	Directory  string
+	RemoteName string
+}
+
+func (s FoundSource) String() string {
+	if s.Directory != "" {
+		return s.Directory
+	}
+	return "<" + s.RemoteName + ">"
+}
+
+func NewSearchResultFromTOC(toc TOC, foundIn FoundSource) SearchResult {
 	r := SearchResult{}
 	var es []FoundEntry
 	for _, e := range toc.Data {
@@ -30,7 +42,7 @@ func NewSearchResultFromTOC(toc TOC, foundIn string) SearchResult {
 	return r
 }
 
-func NewFoundEntryFromTOCEntry(e *TOCEntry, foundIn string) FoundEntry {
+func NewFoundEntryFromTOCEntry(e *TOCEntry, foundIn FoundSource) FoundEntry {
 	return FoundEntry{
 		Name:         e.Name,
 		Manufacturer: e.Manufacturer,
@@ -72,7 +84,7 @@ func (r FoundEntry) Merge(other FoundEntry) FoundEntry {
 	return r
 }
 
-func toFoundVersions(versions []TOCVersion, fromRemote string) []FoundVersion {
+func toFoundVersions(versions []TOCVersion, fromRemote FoundSource) []FoundVersion {
 	var r []FoundVersion
 	for _, v := range versions {
 		r = append(r, FoundVersion{

--- a/internal/remotes/fs_test.go
+++ b/internal/remotes/fs_test.go
@@ -16,7 +16,7 @@ func TestNewFileRemote(t *testing.T) {
 	remote, err := NewFileRemote(map[string]any{
 		"type": "file",
 		"loc":  root,
-	}, "")
+	}, EmptySpec)
 	assert.NoError(t, err)
 	assert.Equal(t, root, remote.root)
 
@@ -24,7 +24,7 @@ func TestNewFileRemote(t *testing.T) {
 	remote, err = NewFileRemote(map[string]any{
 		"type": "file",
 		"loc":  root,
-	}, "")
+	}, EmptySpec)
 	assert.NoError(t, err)
 	assert.Equal(t, root, remote.root)
 
@@ -32,7 +32,7 @@ func TestNewFileRemote(t *testing.T) {
 	remote, err = NewFileRemote(map[string]any{
 		"type": "file",
 		"loc":  root,
-	}, "")
+	}, EmptySpec)
 	assert.NoError(t, err)
 	home, _ := os.UserHomeDir()
 	assert.Equal(t, filepath.Join(home, "tm-catalog"), remote.root)
@@ -41,7 +41,7 @@ func TestNewFileRemote(t *testing.T) {
 	remote, err = NewFileRemote(map[string]any{
 		"type": "file",
 		"loc":  root,
-	}, "")
+	}, EmptySpec)
 	assert.NoError(t, err)
 	assert.Equal(t, filepath.Join(home, "tm-catalog"), remote.root)
 
@@ -49,7 +49,7 @@ func TestNewFileRemote(t *testing.T) {
 	remote, err = NewFileRemote(map[string]any{
 		"type": "file",
 		"loc":  root,
-	}, "")
+	}, EmptySpec)
 	assert.NoError(t, err)
 	assert.Equal(t, filepath.Join(home, "tm-catalog"), remote.root)
 
@@ -57,7 +57,7 @@ func TestNewFileRemote(t *testing.T) {
 	remote, err = NewFileRemote(map[string]any{
 		"type": "file",
 		"loc":  root,
-	}, "")
+	}, EmptySpec)
 	assert.NoError(t, err)
 	assert.Equal(t, filepath.ToSlash("c:\\Users\\user\\Desktop\\tm-catalog"), filepath.ToSlash(remote.root))
 
@@ -65,7 +65,7 @@ func TestNewFileRemote(t *testing.T) {
 	remote, err = NewFileRemote(map[string]any{
 		"type": "file",
 		"loc":  root,
-	}, "")
+	}, EmptySpec)
 	assert.NoError(t, err)
 	assert.Equal(t, filepath.ToSlash("C:\\Users\\user\\Desktop\\tm-catalog"), filepath.ToSlash(remote.root))
 
@@ -80,20 +80,20 @@ func TestCreateFileRemoteConfig(t *testing.T) {
 		expRoot  string
 		expErr   bool
 	}{
-		{"../dir/name", "", filepath.Join(filepath.Dir(wd), "/dir/name"), false},
-		{"./dir/name", "", filepath.Join(wd, "dir/name"), false},
-		{"dir/name", "", filepath.Join(wd, "dir/name"), false},
-		{"/dir/name", "", filepath.Join(filepath.VolumeName(wd), "/dir/name"), false},
+		{"../dir/remoteName", "", filepath.Join(filepath.Dir(wd), "/dir/remoteName"), false},
+		{"./dir/remoteName", "", filepath.Join(wd, "dir/remoteName"), false},
+		{"dir/remoteName", "", filepath.Join(wd, "dir/remoteName"), false},
+		{"/dir/remoteName", "", filepath.Join(filepath.VolumeName(wd), "/dir/remoteName"), false},
 		{".", "", filepath.Join(wd), false},
-		{filepath.Join(wd, "dir/name"), "", filepath.Join(wd, "dir/name"), false},
-		{"~/dir/name", "", "~/dir/name", false},
+		{filepath.Join(wd, "dir/remoteName"), "", filepath.Join(wd, "dir/remoteName"), false},
+		{"~/dir/remoteName", "", "~/dir/remoteName", false},
 		{"", ``, "", true},
 		{"", `[]`, "", true},
 		{"", `{}`, "", true},
 		{"", `{"loc":{}}`, "", true},
-		{"", `{"loc":"dir/name"}`, filepath.Join(wd, "dir/name"), false},
-		{"", `{"loc":"/dir/name"}`, filepath.Join(filepath.VolumeName(wd), "/dir/name"), false},
-		{"", `{"loc":"dir/name", "type":"http"}`, "", true},
+		{"", `{"loc":"dir/remoteName"}`, filepath.Join(wd, "dir/remoteName"), false},
+		{"", `{"loc":"/dir/remoteName"}`, filepath.Join(filepath.VolumeName(wd), "/dir/remoteName"), false},
+		{"", `{"loc":"dir/remoteName", "type":"http"}`, "", true},
 	}
 
 	for i, test := range tests {
@@ -114,7 +114,7 @@ func TestValidatesRoot(t *testing.T) {
 	remote, _ := NewFileRemote(map[string]any{
 		"type": "file",
 		"loc":  "/temp/surely-does-not-exist-5245874598745",
-	}, "")
+	}, EmptySpec)
 
 	_, err := remote.List(&model.SearchParams{Query: ""})
 	assert.ErrorIs(t, err, ErrRootInvalid)
@@ -130,7 +130,7 @@ func TestFileRemote_Fetch(t *testing.T) {
 	defer os.RemoveAll(temp)
 	r := &FileRemote{
 		root: temp,
-		name: "fr",
+		spec: NewRemoteSpec("fr"),
 	}
 	tmName := "omnicorp-TM-department/omnicorp/omnilamp"
 	fileA := []byte("{\"ver\":\"a\"}")
@@ -177,7 +177,7 @@ func TestFileRemote_Push(t *testing.T) {
 	defer os.RemoveAll(temp)
 	r := &FileRemote{
 		root: temp,
-		name: "fr",
+		spec: NewRemoteSpec("fr"),
 	}
 	tmName := "omnicorp-TM-department/omnicorp/omnilamp"
 	id := tmName + "/v0.0.0-20231208142856-c49617d2e4fc.tm.json"
@@ -207,7 +207,7 @@ func TestFileRemote_List(t *testing.T) {
 	defer os.RemoveAll(temp)
 	r := &FileRemote{
 		root: temp,
-		name: "fr",
+		spec: NewRemoteSpec("fr"),
 	}
 	copyFile("../../test/data/list/tm-catalog.toc.json", filepath.Join(temp, TOCFilename))
 	list, err := r.List(&model.SearchParams{})
@@ -243,7 +243,7 @@ func TestFileRemote_Versions(t *testing.T) {
 	defer os.RemoveAll(temp)
 	r := &FileRemote{
 		root: temp,
-		name: "fr",
+		spec: NewRemoteSpec("fr"),
 	}
 	copyFile("../../test/data/list/tm-catalog.toc.json", filepath.Join(temp, TOCFilename))
 	vers, err := r.Versions("omnicorp-R-D-research/omnicorp-Gmbh-Co-KG/senseall/a/b")
@@ -266,5 +266,5 @@ func TestFileRemote_Versions(t *testing.T) {
 	assert.Len(t, vers.Versions, 1)
 
 	vers, err = r.Versions("")
-	assert.ErrorContains(t, err, "specify a name")
+	assert.ErrorContains(t, err, "specify a remoteName")
 }

--- a/internal/remotes/http_test.go
+++ b/internal/remotes/http_test.go
@@ -15,10 +15,10 @@ func TestNewHttpRemote(t *testing.T) {
 		map[string]any{
 			"type": "http",
 			"loc":  root,
-		}, "name")
+		}, NewRemoteSpec("remoteName"))
 	assert.NoError(t, err)
 	assert.Equal(t, root, remote.root)
-	assert.Equal(t, "name", remote.Name())
+	assert.Equal(t, NewRemoteSpec("remoteName"), remote.Spec())
 }
 
 func TestCreateHttpRemoteConfig(t *testing.T) {
@@ -65,7 +65,7 @@ func TestHttpRemote_Fetch(t *testing.T) {
 
 	config, err := createHttpRemoteConfig("", []byte(`{"loc":"`+srv.URL+`", "type":"http", "auth":{"bearer":"token123"}}`))
 	assert.NoError(t, err)
-	r, err := NewHttpRemote(config, "nameless")
+	r, err := NewHttpRemote(config, NewRemoteSpec("nameless"))
 	assert.NoError(t, err)
 	actId, b, err := r.Fetch(tmid)
 	assert.NoError(t, err)

--- a/internal/remotes/mock_Remote.go
+++ b/internal/remotes/mock_Remote.go
@@ -95,24 +95,6 @@ func (_m *MockRemote) List(search *model.SearchParams) (model.SearchResult, erro
 	return r0, r1
 }
 
-// Name provides a mock function with given fields:
-func (_m *MockRemote) Name() string {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for Name")
-	}
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
 // Push provides a mock function with given fields: id, raw
 func (_m *MockRemote) Push(id model.TMID, raw []byte) error {
 	ret := _m.Called(id, raw)
@@ -126,6 +108,24 @@ func (_m *MockRemote) Push(id model.TMID, raw []byte) error {
 		r0 = rf(id, raw)
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Spec provides a mock function with given fields:
+func (_m *MockRemote) Spec() RepoSpec {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Spec")
+	}
+
+	var r0 RepoSpec
+	if rf, ok := ret.Get(0).(func() RepoSpec); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(RepoSpec)
 	}
 
 	return r0

--- a/internal/remotes/mock_RemoteManager.go
+++ b/internal/remotes/mock_RemoteManager.go
@@ -57,9 +57,9 @@ func (_m *MockRemoteManager) All() ([]Remote, error) {
 	return r0, r1
 }
 
-// Get provides a mock function with given fields: name
-func (_m *MockRemoteManager) Get(name string) (Remote, error) {
-	ret := _m.Called(name)
+// Get provides a mock function with given fields: spec
+func (_m *MockRemoteManager) Get(spec RepoSpec) (Remote, error) {
+	ret := _m.Called(spec)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -67,19 +67,19 @@ func (_m *MockRemoteManager) Get(name string) (Remote, error) {
 
 	var r0 Remote
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (Remote, error)); ok {
-		return rf(name)
+	if rf, ok := ret.Get(0).(func(RepoSpec) (Remote, error)); ok {
+		return rf(spec)
 	}
-	if rf, ok := ret.Get(0).(func(string) Remote); ok {
-		r0 = rf(name)
+	if rf, ok := ret.Get(0).(func(RepoSpec) Remote); ok {
+		r0 = rf(spec)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(Remote)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(name)
+	if rf, ok := ret.Get(1).(func(RepoSpec) error); ok {
+		r1 = rf(spec)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/remotes/remote_test.go
+++ b/internal/remotes/remote_test.go
@@ -4,6 +4,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/kinbiko/jsonassert"
@@ -63,66 +65,102 @@ func TestSaveConfigOverwritesOnlyRemotes(t *testing.T) {
 
 func TestRemoteManager_All_And_Get(t *testing.T) {
 	rm := remoteManager{}
-	viper.Set(KeyRemotes, map[string]any{
-		"r1": map[string]string{
-			"type": "file",
-			"loc":  "somewhere",
-		},
+	t.Run("invalid remotes config", func(t *testing.T) {
+
+		viper.Set(KeyRemotes, map[string]any{
+			"r1": map[string]string{
+				"type": "file",
+				"loc":  "somewhere",
+			},
+		})
+
+		_, err := rm.All()
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "invalid remote config")
+
 	})
-
-	_, err := rm.All()
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "invalid remote config")
-
 	const ur = "http://example.com/{{ID}}"
-	viper.Set(KeyRemotes, map[string]any{
-		"r1": map[string]any{
-			"type": "file",
-			"loc":  "somewhere",
-		},
-		"r2": map[string]any{
-			"type": "http",
-			"loc":  ur,
-		},
+
+	t.Run("two remotes", func(t *testing.T) {
+
+		viper.Set(KeyRemotes, map[string]any{
+			"r1": map[string]any{
+				"type": "file",
+				"loc":  "somewhere",
+			},
+			"r2": map[string]any{
+				"type": "http",
+				"loc":  ur,
+			},
+		})
+
+		t.Run("all", func(t *testing.T) {
+			all, err := rm.All()
+			assert.NoError(t, err)
+			assert.Len(t, all, 2)
+			assert.NotEqual(t, -1, slices.IndexFunc(all, func(remote Remote) bool { return reflect.TypeOf(remote) == reflect.TypeOf(&FileRemote{}) }))
+			assert.NotEqual(t, -1, slices.IndexFunc(all, func(remote Remote) bool { return reflect.TypeOf(remote) == reflect.TypeOf(&HttpRemote{}) }))
+		})
+		t.Run("file remote", func(t *testing.T) {
+
+			fr, err := rm.Get(NewRemoteSpec("r1"))
+			assert.NoError(t, err)
+			assert.Equal(t, &FileRemote{
+				root: "somewhere",
+				spec: NewRemoteSpec("r1"),
+			}, fr)
+
+		})
+		t.Run("http remote", func(t *testing.T) {
+
+			hr, err := rm.Get(NewRemoteSpec("r2"))
+			assert.NoError(t, err)
+			u, _ := url.Parse(ur)
+			assert.Equal(t, &HttpRemote{
+				root:           ur,
+				parsedRoot:     u,
+				templatedPath:  true,
+				templatedQuery: false,
+				spec:           NewRemoteSpec("r2"),
+			}, hr)
+		})
+		t.Run("ad-hoc remote", func(t *testing.T) {
+			ar, err := rm.Get(NewDirSpec("directory"))
+			assert.NoError(t, err)
+			assert.Equal(t, &FileRemote{
+				root: "directory",
+				spec: RepoSpec{"", "directory"},
+			}, ar)
+		})
+
+		t.Run("invalid spec", func(t *testing.T) {
+			_, err := rm.Get(RepoSpec{"name", "dir"})
+			assert.Error(t, err)
+		})
+
 	})
-	all, err := rm.All()
-	assert.NoError(t, err)
-	assert.Len(t, all, 2)
-	assert.IsType(t, &FileRemote{}, all[0])
-	assert.IsType(t, &HttpRemote{}, all[1])
-
-	fr, err := rm.Get("r1")
-	assert.NoError(t, err)
-	assert.Equal(t, &FileRemote{
-		root: "somewhere",
-		name: "r1",
-	}, fr)
-
-	hr, err := rm.Get("r2")
-	assert.NoError(t, err)
-	u, _ := url.Parse(ur)
-	assert.Equal(t, &HttpRemote{
-		root:           ur,
-		parsedRoot:     u,
-		templatedPath:  true,
-		templatedQuery: false,
-		name:           "r2",
-	}, hr)
 
 }
 
-func TestGetNamedOrAll(t *testing.T) {
+func TestGetSpecdOrAll(t *testing.T) {
 	rm := NewMockRemoteManager(t)
 	r1 := NewMockRemote(t)
 	r2 := NewMockRemote(t)
+	r3 := NewMockRemote(t)
 
 	rm.On("All").Return([]Remote{r1, r2}, nil)
-	all, err := GetNamedOrAll(rm, "")
+	all, err := GetSpecdOrAll(rm, EmptySpec)
 	assert.NoError(t, err)
 	assert.Equal(t, []Remote{r1, r2}, all)
 
-	rm.On("Get", "r1").Return(r1, nil)
-	all, err = GetNamedOrAll(rm, "r1")
+	rm.On("Get", NewRemoteSpec("r1")).Return(r1, nil)
+	all, err = GetSpecdOrAll(rm, NewRemoteSpec("r1"))
 	assert.NoError(t, err)
 	assert.Equal(t, []Remote{r1}, all)
+
+	rm.On("Get", NewDirSpec("dir1")).Return(r3, nil)
+	all, err = GetSpecdOrAll(rm, NewDirSpec("dir1"))
+	assert.NoError(t, err)
+	assert.Equal(t, []Remote{r3}, all)
+
 }


### PR DESCRIPTION
- feat: enable using a directory as an ad-hoc TM repository
- fix(fetch): search in all repositories when multiple remotes configured

closes #46 