### PR TITLE
feat: add CORS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Added
 
 - Implemented file locking to avoid data races (guaranteed for Linux/MacOSX)
-- Implemented ```pull``` command to fetch and save multiple thing models at once 
+- Implemented ```pull``` command to fetch and save multiple thing models at once
+- Implemented setting CORS options for API
 
 ### Changed
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -5,8 +5,10 @@ import (
 	"os"
 
 	"github.com/spf13/viper"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal/app/http"
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/config"
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/remotes"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal/utils"
 
 	"github.com/spf13/cobra"
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/app/cli"
@@ -31,7 +33,14 @@ func init() {
 	serveCmd.Flags().StringP("pushTarget", "t", "", "name of the remote to use as target for push operations")
 	serveCmd.Flags().StringP("urlContextRoot", "", "",
 		"define additional URL context root path to be considered in hypermedia links,\ncan also be set via environment variable TMC_URLCONTEXTROOT")
+	serveCmd.Flags().StringP("corsAllowedOrigins", "", "", "set comma-separated list for CORS allowed origins")
+	serveCmd.Flags().StringP("corsAllowedHeaders", "", "", "set comma-separated list for CORS allowed headers")
+	serveCmd.Flags().BoolP("corsAllowCredentials", "", false, "set CORS allow credentials")
+
 	_ = viper.BindPFlag(config.KeyUrlContextRoot, serveCmd.Flags().Lookup("urlContextRoot"))
+	_ = viper.BindPFlag(config.KeyCorsAllowedOrigins, serveCmd.Flags().Lookup("corsAllowedOrigins"))
+	_ = viper.BindPFlag(config.KeyCorsAllowedHeaders, serveCmd.Flags().Lookup("corsAllowedHeaders"))
+	_ = viper.BindPFlag(config.KeyCorsAllowCredentials, serveCmd.Flags().Lookup("corsAllowCredentials"))
 }
 
 func serve(cmd *cobra.Command, args []string) {
@@ -47,13 +56,25 @@ func serve(cmd *cobra.Command, args []string) {
 	}
 
 	urlCtxRoot := viper.GetString(config.KeyUrlContextRoot)
+	opts := getServerOptions()
+
 	pushSpec := spec
 	if pushTarget != "" {
 		pushSpec = remotes.NewRemoteSpec(pushTarget)
 	}
-	err = cli.Serve(host, port, urlCtxRoot, spec, pushSpec)
+	err = cli.Serve(host, port, urlCtxRoot, opts, spec, pushSpec)
 	if err != nil {
 		cli.Stderrf("serve failed")
 		os.Exit(1)
 	}
+}
+
+func getServerOptions() http.ServerOptions {
+	opts := http.ServerOptions{}
+
+	opts.CORS.AddAllowedOrigins(utils.ParseAsList(viper.GetString(config.KeyCorsAllowedOrigins), cli.DefaultListSeparator, true)...)
+	opts.CORS.AddAllowedHeaders(utils.ParseAsList(viper.GetString(config.KeyCorsAllowedHeaders), cli.DefaultListSeparator, true)...)
+	opts.CORS.AddAllowCredentials(viper.GetBool(config.KeyCorsAllowCredentials))
+
+	return opts
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -36,11 +36,13 @@ func init() {
 	serveCmd.Flags().StringP("corsAllowedOrigins", "", "", "set comma-separated list for CORS allowed origins")
 	serveCmd.Flags().StringP("corsAllowedHeaders", "", "", "set comma-separated list for CORS allowed headers")
 	serveCmd.Flags().BoolP("corsAllowCredentials", "", false, "set CORS allow credentials")
+	serveCmd.Flags().IntP("corsMaxAge", "", 0, "set how long result of CORS preflight request can be cached in seconds (default 0, max 600)")
 
 	_ = viper.BindPFlag(config.KeyUrlContextRoot, serveCmd.Flags().Lookup("urlContextRoot"))
 	_ = viper.BindPFlag(config.KeyCorsAllowedOrigins, serveCmd.Flags().Lookup("corsAllowedOrigins"))
 	_ = viper.BindPFlag(config.KeyCorsAllowedHeaders, serveCmd.Flags().Lookup("corsAllowedHeaders"))
 	_ = viper.BindPFlag(config.KeyCorsAllowCredentials, serveCmd.Flags().Lookup("corsAllowCredentials"))
+	_ = viper.BindPFlag(config.KeyCorsMaxAge, serveCmd.Flags().Lookup("corsMaxAge"))
 }
 
 func serve(cmd *cobra.Command, args []string) {
@@ -74,7 +76,8 @@ func getServerOptions() http.ServerOptions {
 
 	opts.CORS.AddAllowedOrigins(utils.ParseAsList(viper.GetString(config.KeyCorsAllowedOrigins), cli.DefaultListSeparator, true)...)
 	opts.CORS.AddAllowedHeaders(utils.ParseAsList(viper.GetString(config.KeyCorsAllowedHeaders), cli.DefaultListSeparator, true)...)
-	opts.CORS.AddAllowCredentials(viper.GetBool(config.KeyCorsAllowCredentials))
+	opts.CORS.AllowCredentials(viper.GetBool(config.KeyCorsAllowCredentials))
+	opts.CORS.MaxAge(viper.GetInt(config.KeyCorsMaxAge))
 
 	return opts
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -20,10 +20,12 @@ func TestGetServerOptionsReadsFromEnvironment(t *testing.T) {
 		envAllowedHeaders := buildTMCEnvVar(config.KeyCorsAllowedHeaders)
 		envAllowedOrigins := buildTMCEnvVar(config.KeyCorsAllowedOrigins)
 		envAllowCredentials := buildTMCEnvVar(config.KeyCorsAllowCredentials)
+		envMaxAge := buildTMCEnvVar(config.KeyCorsMaxAge)
 
 		t.Setenv(envAllowedHeaders, "X-Api-Key, X-Bar")
 		t.Setenv(envAllowedOrigins, "http://example.org, https://sample.com")
 		t.Setenv(envAllowCredentials, "true")
+		t.Setenv(envMaxAge, "120")
 		config.InitViper()
 
 		opts := getServerOptions()
@@ -31,12 +33,14 @@ func TestGetServerOptionsReadsFromEnvironment(t *testing.T) {
 		corsOrigins := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("allowedOrigins"))
 		corsHeaders := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("allowedHeaders"))
 		corsCredentials := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("allowCredentials"))
+		corsMaxAge := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("maxAge"))
 
 		assert.True(t, strings.Contains(corsOrigins, "http://example.org"))
 		assert.True(t, strings.Contains(corsOrigins, "https://sample.com"))
 		assert.True(t, strings.Contains(corsHeaders, "X-Api-Key"))
 		assert.True(t, strings.Contains(corsHeaders, "X-Bar"))
 		assert.Equal(t, "true", corsCredentials)
+		assert.Equal(t, "120", corsMaxAge)
 	})
 
 	t.Run("without set environment variables", func(t *testing.T) {
@@ -47,9 +51,11 @@ func TestGetServerOptionsReadsFromEnvironment(t *testing.T) {
 		corsOrigins := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("allowedOrigins"))
 		corsHeaders := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("allowedHeaders"))
 		corsCredentials := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("allowCredentials"))
+		corsMaxAge := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("maxAge"))
 
 		assert.Equal(t, "[]", corsOrigins)
 		assert.Equal(t, "[]", corsHeaders)
 		assert.Equal(t, "false", corsCredentials)
+		assert.Equal(t, "0", corsMaxAge)
 	})
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal/config"
+)
+
+func buildTMCEnvVar(name string) string {
+	return strings.ToUpper(config.EnvPrefix + "_" + name)
+}
+
+func TestGetServerOptionsReadsFromEnvironment(t *testing.T) {
+
+	t.Run("with set environment variables", func(t *testing.T) {
+		envAllowedHeaders := buildTMCEnvVar(config.KeyCorsAllowedHeaders)
+		envAllowedOrigins := buildTMCEnvVar(config.KeyCorsAllowedOrigins)
+		envAllowCredentials := buildTMCEnvVar(config.KeyCorsAllowCredentials)
+
+		t.Setenv(envAllowedHeaders, "X-Api-Key, X-Bar")
+		t.Setenv(envAllowedOrigins, "http://example.org, https://sample.com")
+		t.Setenv(envAllowCredentials, "true")
+		config.InitViper()
+
+		opts := getServerOptions()
+
+		corsOrigins := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("allowedOrigins"))
+		corsHeaders := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("allowedHeaders"))
+		corsCredentials := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("allowCredentials"))
+
+		assert.True(t, strings.Contains(corsOrigins, "http://example.org"))
+		assert.True(t, strings.Contains(corsOrigins, "https://sample.com"))
+		assert.True(t, strings.Contains(corsHeaders, "X-Api-Key"))
+		assert.True(t, strings.Contains(corsHeaders, "X-Bar"))
+		assert.Equal(t, "true", corsCredentials)
+	})
+
+	t.Run("without set environment variables", func(t *testing.T) {
+		config.InitViper()
+
+		opts := getServerOptions()
+
+		corsOrigins := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("allowedOrigins"))
+		corsHeaders := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("allowedHeaders"))
+		corsCredentials := fmt.Sprintf("%v", reflect.ValueOf(opts.CORS).FieldByName("allowCredentials"))
+
+		assert.Equal(t, "[]", corsOrigins)
+		assert.Equal(t, "[]", corsHeaders)
+		assert.Equal(t, "false", corsCredentials)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,10 @@ require (
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/google/uuid v1.4.0 // indirect
+	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -134,6 +136,8 @@ github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
+github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -166,12 +170,12 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/oapi-codegen/runtime v1.1.0 h1:rJpoNUawn5XTvekgfkvSZr0RqEnoYpFkyvrzfWeFKWM=
 github.com/oapi-codegen/runtime v1.1.0/go.mod h1:BeSfBkWWWnAnGdyS+S/GnlbmHKzf8/hwkvelJZDeKA8=
+github.com/oapi-codegen/testutil v1.1.0 h1:EufqpNg43acR3qzr3ObhXmWg3Sl2kwtRnUN5GYY4d5g=
+github.com/oapi-codegen/testutil v1.1.0/go.mod h1:ttCaYbHvJtHuiyeBF0tPIX+4uhEPTeizXKx28okijLw=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
 github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
 github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
 github.com/otiai10/mint v1.5.1/go.mod h1:MJm72SBthJjz8qhefc4z1PYEieWmy8Bku7CjcAqyUSM=
-github.com/oapi-codegen/testutil v1.1.0 h1:EufqpNg43acR3qzr3ObhXmWg3Sl2kwtRnUN5GYY4d5g=
-github.com/oapi-codegen/testutil v1.1.0/go.mod h1:ttCaYbHvJtHuiyeBF0tPIX+4uhEPTeizXKx28okijLw=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/app/cli/common.go
+++ b/internal/app/cli/common.go
@@ -11,7 +11,7 @@ import (
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/model"
 )
 
-const filterSep = ","
+const DefaultListSeparator = ","
 
 // Stderrf prints a message to os.Stderr, followed by newline
 func Stderrf(format string, args ...any) {
@@ -38,16 +38,16 @@ func CreateSearchParamsFromCLI(flags FilterFlags, name string) *model.SearchPara
 	if flags.IsSet() || name != "" {
 		search = &model.SearchParams{}
 		if flags.FilterAuthor != "" {
-			search.Author = strings.Split(flags.FilterAuthor, filterSep)
+			search.Author = strings.Split(flags.FilterAuthor, DefaultListSeparator)
 		}
 		if flags.FilterManufacturer != "" {
-			search.Manufacturer = strings.Split(flags.FilterManufacturer, filterSep)
+			search.Manufacturer = strings.Split(flags.FilterManufacturer, DefaultListSeparator)
 		}
 		if flags.FilterMpn != "" {
-			search.Mpn = strings.Split(flags.FilterMpn, filterSep)
+			search.Mpn = strings.Split(flags.FilterMpn, DefaultListSeparator)
 		}
 		if flags.FilterExternalID != "" {
-			search.ExternalID = strings.Split(flags.FilterExternalID, filterSep)
+			search.ExternalID = strings.Split(flags.FilterExternalID, DefaultListSeparator)
 		}
 		if flags.Search != "" {
 			search.Query = flags.Search

--- a/internal/app/cli/serve.go
+++ b/internal/app/cli/serve.go
@@ -11,7 +11,7 @@ import (
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/remotes"
 )
 
-func Serve(host, port, urlCtxRoot string, repo, pushTarget remotes.RepoSpec) error {
+func Serve(host, port, urlCtxRoot string, opts http.ServerOptions, repo, pushTarget remotes.RepoSpec) error {
 
 	err := validateContextRoot(urlCtxRoot)
 	if err != nil {
@@ -30,9 +30,7 @@ func Serve(host, port, urlCtxRoot string, repo, pushTarget remotes.RepoSpec) err
 		return err
 	}
 
-	// create an instance of a router and our handler
-	r := http.NewRouter()
-
+	// create an instance of our handler (server interface)
 	handlerService, err := http.NewDefaultHandlerService(remotes.DefaultManager(), repo, pushTarget)
 	if err != nil {
 		Stderrf("Could not start tm-catalog server on %s:%s, %v\n", host, port, err)
@@ -44,14 +42,12 @@ func Serve(host, port, urlCtxRoot string, repo, pushTarget remotes.RepoSpec) err
 			UrlContextRoot: urlCtxRoot,
 		})
 
-	options := http.GorillaServerOptions{
-		BaseRouter:       r,
-		ErrorHandlerFunc: http.HandleErrorResponse,
-	}
-	http.HandlerWithOptions(handler, options)
+	// create a http handler
+	httpHandler := http.NewHttpHandler(handler)
+	httpHandler = http.WithCORS(httpHandler, opts)
 
 	s := &nethttp.Server{
-		Handler: r,
+		Handler: httpHandler,
 		Addr:    net.JoinHostPort(host, port),
 	}
 

--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-
-	"github.com/gorilla/mux"
 )
 
 // Hint for generating the server code based on the openapi spec:
@@ -28,16 +26,6 @@ type TmcHandler struct {
 
 type TmcHandlerOptions struct {
 	UrlContextRoot string
-}
-
-func NewRouter() *mux.Router {
-	r := mux.NewRouter()
-	r.NotFoundHandler = http.HandlerFunc(handleNoRoute)
-	return r
-}
-
-func handleNoRoute(w http.ResponseWriter, r *http.Request) {
-	HandleErrorResponse(w, r, NewNotFoundError(nil, "Path not handled by Thing Model Catalog"))
 }
 
 func NewTmcHandler(handlerService HandlerService, options TmcHandlerOptions) *TmcHandler {

--- a/internal/app/http/server.go
+++ b/internal/app/http/server.go
@@ -1,0 +1,74 @@
+package http
+
+import (
+	"net/http"
+	"slices"
+
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+)
+
+type ServerOptions struct {
+	CORS CORSOptions
+}
+
+type CORSOptions struct {
+	allowedOrigins   []string
+	allowedHeaders   []string
+	allowCredentials bool
+}
+
+func (co *CORSOptions) AddAllowedOrigins(origins ...string) {
+	for _, origin := range origins {
+		if origin != "" && !slices.Contains(co.allowedOrigins, origin) {
+			co.allowedOrigins = append(co.allowedOrigins, origin)
+		}
+	}
+}
+
+func (co *CORSOptions) AddAllowedHeaders(headers ...string) {
+	for _, header := range headers {
+		if header != "" && !slices.Contains(co.allowedHeaders, header) {
+			co.allowedHeaders = append(co.allowedHeaders, header)
+		}
+	}
+}
+
+func (co *CORSOptions) AddAllowCredentials(allow bool) {
+	co.allowCredentials = allow
+}
+
+func NewHttpHandler(si ServerInterface) http.Handler {
+	r := mux.NewRouter()
+	r.NotFoundHandler = http.HandlerFunc(handleNoRoute)
+	options := GorillaServerOptions{
+		BaseRouter:       r,
+		ErrorHandlerFunc: HandleErrorResponse,
+	}
+	return HandlerWithOptions(si, options)
+}
+
+func WithCORS(h http.Handler, opts ServerOptions) http.Handler {
+	// add supported default values to the CORS options
+	opts.CORS.AddAllowedHeaders(headerContentType)
+
+	// add CORS middleware to the http handler
+	var corsOpts []handlers.CORSOption
+	corsOpts = append(corsOpts, handlers.AllowedHeaders(opts.CORS.allowedHeaders))
+	corsOpts = append(corsOpts, handlers.AllowedOrigins(opts.CORS.allowedOrigins))
+	corsOpts = append(corsOpts, handlers.AllowedMethods([]string{
+		http.MethodGet,
+		http.MethodPost,
+		http.MethodPatch,
+		http.MethodOptions,
+		http.MethodHead,
+		http.MethodDelete}))
+	if opts.CORS.allowCredentials {
+		corsOpts = append(corsOpts, handlers.AllowCredentials())
+	}
+	return handlers.CORS(corsOpts...)(h)
+}
+
+func handleNoRoute(w http.ResponseWriter, r *http.Request) {
+	HandleErrorResponse(w, r, NewNotFoundError(nil, "Path not handled by Thing Model Catalog"))
+}

--- a/internal/app/http/server.go
+++ b/internal/app/http/server.go
@@ -16,6 +16,7 @@ type CORSOptions struct {
 	allowedOrigins   []string
 	allowedHeaders   []string
 	allowCredentials bool
+	maxAge           int
 }
 
 func (co *CORSOptions) AddAllowedOrigins(origins ...string) {
@@ -34,8 +35,12 @@ func (co *CORSOptions) AddAllowedHeaders(headers ...string) {
 	}
 }
 
-func (co *CORSOptions) AddAllowCredentials(allow bool) {
+func (co *CORSOptions) AllowCredentials(allow bool) {
 	co.allowCredentials = allow
+}
+
+func (co *CORSOptions) MaxAge(max int) {
+	co.maxAge = max
 }
 
 func NewHttpHandler(si ServerInterface) http.Handler {
@@ -63,9 +68,14 @@ func WithCORS(h http.Handler, opts ServerOptions) http.Handler {
 		http.MethodOptions,
 		http.MethodHead,
 		http.MethodDelete}))
+
 	if opts.CORS.allowCredentials {
 		corsOpts = append(corsOpts, handlers.AllowCredentials())
 	}
+	if opts.CORS.maxAge > 0 {
+		corsOpts = append(corsOpts, handlers.MaxAge(opts.CORS.maxAge))
+	}
+
 	return handlers.CORS(corsOpts...)(h)
 }
 

--- a/internal/app/http/server_test.go
+++ b/internal/app/http/server_test.go
@@ -1,0 +1,103 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/oapi-codegen/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCORSOptions(t *testing.T) {
+
+	underTest := CORSOptions{}
+
+	// when: adding origins
+	underTest.AddAllowedOrigins("http://example.org", "", "*", "https://example.org:8080", "http://example.org")
+	// then: duplicates and empty ones are removed
+	assert.Equal(t, []string{"http://example.org", "*", "https://example.org:8080"}, underTest.allowedOrigins)
+
+	// when: adding headers
+	underTest.AddAllowedHeaders("X-Api-Key", "", "Content-Type", "Content-Type")
+	// then: duplicates and empty ones are removed
+	assert.Equal(t, []string{"X-Api-Key", "Content-Type"}, underTest.allowedHeaders)
+
+	assert.False(t, underTest.allowCredentials)
+	underTest.AddAllowCredentials(true)
+	assert.True(t, underTest.allowCredentials)
+}
+
+func TestWithCORS(t *testing.T) {
+	// given: some CORS options to be set on the CORS middleware handler
+	cOpts := CORSOptions{}
+	cOpts.AddAllowedHeaders("X-Api-Key", "X-Bar")
+	cOpts.AddAllowedOrigins("http://example.org", "https://sample.com")
+	cOpts.AddAllowCredentials(true)
+
+	sOpts := ServerOptions{
+		CORS: cOpts,
+	}
+
+	// and given: a http handler not CORS aware
+	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	// when: setting CORS on the http handler
+	corsHdl := WithCORS(hf, sOpts)
+
+	immutable := reflect.ValueOf(corsHdl)
+	corsOrigins := fmt.Sprintf("%v", reflect.Indirect(immutable).FieldByName("allowedOrigins"))
+	corsHeaders := fmt.Sprintf("%v", reflect.Indirect(immutable).FieldByName("allowedHeaders"))
+	corsCredentials := fmt.Sprintf("%v", reflect.Indirect(immutable).FieldByName("allowCredentials"))
+
+	// then: origins are set correct on CORS middleware handler
+	assert.Equal(t, "[http://example.org https://sample.com]", corsOrigins)
+	// then: headers contain the default CORS allowed header, the manual allowed header and the default header set by WithCORS()
+	assert.Equal(t, "[Accept Accept-Language Content-Language Origin X-Api-Key X-Bar Content-Type]", corsHeaders)
+	// then: allow credentials is set correct on CORS middleware handler
+	assert.Equal(t, "true", corsCredentials)
+}
+
+func TestWithCORSOnRequest(t *testing.T) {
+	route := "/inventory"
+	allowedOrigin := "http://example.org"
+	notAllowedOrigin := "http://not-allowed.org"
+
+	// given: CORS options with an allowed origin
+	co := CORSOptions{}
+	co.AddAllowedOrigins(allowedOrigin)
+	opts := ServerOptions{
+		CORS: co,
+	}
+
+	// and given: a http handler without CORS
+	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	// when setting CORS on the handler
+	hdl := WithCORS(hf, opts)
+
+	t.Run("request with an allowed origin", func(t *testing.T) {
+		// and when: making an options request
+		rec := testutil.NewRequest().WithMethod(http.MethodOptions, route).
+			WithHeader("origin", allowedOrigin).
+			WithHeader("Access-Control-Request-Method", http.MethodPost).
+			GoWithHTTPHandler(t, hdl).
+			Recorder
+
+		// then: the response header "Access-Control-Allow-Origin" contains the allowed origin
+		assert.Equal(t, allowedOrigin, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("request with a not allowed origin", func(t *testing.T) {
+		// and when: making an options request
+		rec := testutil.NewRequest().WithMethod(http.MethodOptions, route).
+			WithHeader("origin", notAllowedOrigin).
+			WithHeader("Access-Control-Request-Method", http.MethodPost).
+			GoWithHTTPHandler(t, hdl).
+			Recorder
+
+		// then: the response header "Access-Control-Allow-Origin" is not present
+		assert.Equal(t, "", rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ const (
 	KeyCorsAllowedOrigins   = "corsAllowedOrigins"
 	KeyCorsAllowedHeaders   = "corsAllowedHeaders"
 	KeyCorsAllowCredentials = "corsAllowCredentials"
+	KeyCorsMaxAge           = "corsMaxAge"
 	EnvPrefix               = "tmc"
 )
 
@@ -56,4 +57,5 @@ func InitViper() {
 	_ = viper.BindEnv(KeyCorsAllowedOrigins)   // env variable name = TMC_CORSALLOWEDORIGINS
 	_ = viper.BindEnv(KeyCorsAllowedHeaders)   // env variable name = TMC_CORSALLOWEDHEADERS
 	_ = viper.BindEnv(KeyCorsAllowCredentials) // env variable name = TMC_CORSALLOWCREDENTIALS
+	_ = viper.BindEnv(KeyCorsMaxAge)           // env variable name = TMC_CORSMAXAGE
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,10 +8,13 @@ import (
 )
 
 const (
-	KeyLog            = "log"
-	KeyLogLevel       = "logLevel"
-	KeyUrlContextRoot = "urlContextRoot"
-	EnvPrefix         = "tmc"
+	KeyLog                  = "log"
+	KeyLogLevel             = "logLevel"
+	KeyUrlContextRoot       = "urlContextRoot"
+	KeyCorsAllowedOrigins   = "corsAllowedOrigins"
+	KeyCorsAllowedHeaders   = "corsAllowedHeaders"
+	KeyCorsAllowCredentials = "corsAllowCredentials"
+	EnvPrefix               = "tmc"
 )
 
 var HomeDir string
@@ -46,8 +49,11 @@ func InitViper() {
 	// set prefix "tmc" for environment variables
 	// the environment variables then have to match pattern "tmc_<viper variable>", lower or uppercase
 	viper.SetEnvPrefix(EnvPrefix)
-	// bind viper variable "log" to env (TMC_LOG)
-	_ = viper.BindEnv(KeyLog)
-	// bind viper variable "urlContextRoot" to env (TMC_URLCONTEXTROOT)
-	_ = viper.BindEnv(KeyUrlContextRoot)
+
+	// bind viper variables to environment variables
+	_ = viper.BindEnv(KeyLog)                  // env variable name = TMC_LOG
+	_ = viper.BindEnv(KeyUrlContextRoot)       // env variable name = TMC_URLCONTEXTROOT
+	_ = viper.BindEnv(KeyCorsAllowedOrigins)   // env variable name = TMC_CORSALLOWEDORIGINS
+	_ = viper.BindEnv(KeyCorsAllowedHeaders)   // env variable name = TMC_CORSALLOWEDHEADERS
+	_ = viper.BindEnv(KeyCorsAllowCredentials) // env variable name = TMC_CORSALLOWCREDENTIALS
 }

--- a/internal/utils/util.go
+++ b/internal/utils/util.go
@@ -129,3 +129,17 @@ func ConvertToNativeLineEndings(b []byte) []byte {
 func AtomicWriteFile(name string, data []byte, perm os.FileMode) error {
 	return atomicWriteFile(name, data, perm)
 }
+
+func ParseAsList(list, separator string, trim bool) []string {
+	ret := make([]string, 0)
+
+	for _, entry := range strings.Split(list, separator) {
+		if trim {
+			entry = strings.TrimSpace(entry)
+		}
+		if entry != "" {
+			ret = append(ret, entry)
+		}
+	}
+	return ret
+}

--- a/internal/utils/util_test.go
+++ b/internal/utils/util_test.go
@@ -26,3 +26,24 @@ func TestNormalizeLineEndings(t *testing.T) {
 		assert.Equal(t, []byte(test.out), NormalizeLineEndings([]byte(test.in)), "in test %d", i)
 	}
 }
+
+func TestParseAsList(t *testing.T) {
+
+	tests := []struct {
+		in   string
+		sep  string
+		trim bool
+		out  []string
+	}{
+		{"1,2,3,4,5", ",", true, []string{"1", "2", "3", "4", "5"}},
+		{"1,2,3,4,5,4,3,1", ",", true, []string{"1", "2", "3", "4", "5", "4", "3", "1"}},
+		{"1,2,3,,4,,5", ",", true, []string{"1", "2", "3", "4", "5"}},
+		{"1, 2 ,3 ,4,5 ", ",", true, []string{"1", "2", "3", "4", "5"}},
+		{"1, 2 ,3 ,4,5 ", ",", false, []string{"1", " 2 ", "3 ", "4", "5 "}},
+		{"1,2,3,4,5", "/", true, []string{"1,2,3,4,5"}},
+	}
+
+	for i, test := range tests {
+		assert.Equal(t, test.out, ParseAsList(test.in, test.sep, test.trim), "in test %d", i)
+	}
+}


### PR DESCRIPTION
Changes:

+ added CORS support for API, configurable on CLI `serve` command
   + `allowedOrigins` can be set via `--corsAllowedOrigins` or via environment variable `TMC_CORSALLOWEDORIGINS`
   + `allowedHeaders` can be set via `--corsAllowedHeaders` or via environment variable `TMC_CORSALLOWEDHEADERS`
   + `allowCredentials` can be set via `--corsAllowCredentials` or via environment variable `TMC_CORSALLOWCREDENTIALS`
   + `maxAge` can be set via `--corsMaxAge` or via environment variable `TMC_CORSMAXAGE`
   
