### PR TITLE
feat: change behavior of fetch for output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 - ```create-toc```: renamed to ```update-toc``` and allow for partial updates
 - ```list```: allows now listing by name pattern
-- ```serve```: separate configuration of the remote(s) to be served from the target remote for push  
+- ```serve```: separate configuration of the remote(s) to be served from the target remote for push
+- ```fetch```: --output now accepts only a target folder to save TM to, ```--with-tree``` has been removed
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - ```create-toc```: renamed to ```update-toc``` and allow for partial updates
 - ```list```: allows now listing by name pattern
 - ```serve```: separate configuration of the remote(s) to be served from the target remote for push
-- ```fetch```: --output now accepts only a target folder to save TM to, ```--with-tree``` has been removed
+- ```fetch```: ```--output``` now accepts only a target folder to save TM to, ```--with-path``` has been removed
 
 ### Fixed
 

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -10,43 +10,32 @@ import (
 )
 
 var fetchCmd = &cobra.Command{
-	Use:   "fetch (<NAME[:SEMVER|DIGEST]> | <TMID>) [--remote <remoteName>] [--output <filename>] [--with-path]",
+	Use:   "fetch (<NAME[:SEMVER|DIGEST]> | <TMID>)",
 	Short: "Fetches the TM by name or id",
-	Long: `Fetches TM by name, optionally accepting semantic version or digest.
-
---output, -o
-	Write output to a file instead of stdout. If <filename> is an existing folder, the content will be written into
-	a file in that folder. If it's a file or no such file exists, the output is written into a file with given name
---with-path
-	Create the folder structure defined by Thing Model ID under <filename>. --output value must be a folder when --with-path is given`,
-	Args: cobra.ExactArgs(1),
-	Run:  executeFetch,
+	Long:  `Fetches TM by name, optionally accepting semantic version or digest.`,
+	Args:  cobra.ExactArgs(1),
+	Run:   executeFetch,
 }
 
 func init() {
 	RootCmd.AddCommand(fetchCmd)
 	fetchCmd.Flags().StringP("remote", "r", "", "name of the remote to fetch from")
 	fetchCmd.Flags().StringP("directory", "d", "", "TM repository directory")
-	fetchCmd.Flags().StringP("output", "o", "", "write output to a file instead of stdout")
-	fetchCmd.Flags().BoolP("with-path", "", false, "create folder structure under output")
+	fetchCmd.Flags().StringP("output", "o", "", "write the fetched TM to output folder instead of stdout")
 }
 
 func executeFetch(cmd *cobra.Command, args []string) {
 	remoteName := cmd.Flag("remote").Value.String()
 	dirName := cmd.Flag("directory").Value.String()
-	outputFile := cmd.Flag("output").Value.String()
-	withPath, err := cmd.Flags().GetBool("with-path")
-	if err != nil {
-		cli.Stderrf("invalid --with-path flag")
-		os.Exit(1)
-	}
+	outputPath := cmd.Flag("output").Value.String()
+
 	spec, err := remotes.NewSpec(remoteName, dirName)
 	if errors.Is(err, remotes.ErrInvalidSpec) {
 		cli.Stderrf("Invalid specification of target repository. --remote and --directory are mutually exclusive. Set at most one")
 		os.Exit(1)
 	}
 
-	err = cli.NewFetchExecutor(remotes.DefaultManager()).Fetch(spec, args[0], outputFile, withPath)
+	err = cli.NewFetchExecutor(remotes.DefaultManager()).Fetch(spec, args[0], outputPath)
 	if err != nil {
 		cli.Stderrf("fetch failed")
 		os.Exit(1)

--- a/internal/app/cli/fetch_test.go
+++ b/internal/app/cli/fetch_test.go
@@ -31,14 +31,15 @@ func TestFetchExecutor_Fetch_To_Stdout(t *testing.T) {
 		outC <- buf.String()
 	}()
 	err := e.Fetch(remotes.NewRemoteSpec("remote"), "author/manufacturer/mpn/folder/sub/v1.0.0-20231205123243-c49617d2e4fc.tm.json",
-		"", false)
+		"")
 	assert.NoError(t, err)
 	os.Stdout = old
 	_ = w.Close()
 	stdout := <-outC
 	assert.Equal(t, "{}\n", stdout)
 }
-func TestFetchExecutor_Fetch_To_OutputFile(t *testing.T) {
+
+func TestFetchExecutor_Fetch_To_OutputFolder(t *testing.T) {
 	temp, err := os.MkdirTemp("", "fs")
 	assert.NoError(t, err)
 	defer os.RemoveAll(temp)
@@ -52,32 +53,31 @@ func TestFetchExecutor_Fetch_To_OutputFile(t *testing.T) {
 	rm.On("Get", remotes.NewRemoteSpec("remote")).Return(r, nil)
 	r.On("Fetch", tmid).Return(aid, tm, nil)
 
+	// given: a fetch executor
 	e := NewFetchExecutor(rm)
-	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, "", true)
 
-	fileTxt := filepath.Join(temp, "file.txt")
-	_ = os.WriteFile(fileTxt, []byte("text"), 0660)
-	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, fileTxt, true)
-	assert.Error(t, err)
-
-	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, fileTxt, false)
-	assert.NoError(t, err)
-	file, err := os.ReadFile(fileTxt)
-	assert.NoError(t, err)
-	assert.Equal(t, tm, file)
-
-	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, temp, false)
-	assert.NoError(t, err)
-	assert.FileExists(t, filepath.Join(temp, filepath.Base(aid)))
-	file, err = os.ReadFile(filepath.Join(temp, filepath.Base(aid)))
-	assert.NoError(t, err)
-	assert.Equal(t, tm, file)
-
-	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, temp, true)
+	// when: fetching to output folder
+	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, temp)
+	// then: the file exists below the output folder with tree structure given by the ID
 	assert.NoError(t, err)
 	assert.FileExists(t, filepath.Join(temp, aid))
-	file, err = os.ReadFile(filepath.Join(temp, aid))
-	assert.NoError(t, err)
-	assert.Equal(t, tm, file)
+	s, err := os.Stat(filepath.Join(temp, aid))
+	modTimeOld := s.ModTime()
 
+	// when: fetching again the ID to same output folder
+	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, temp)
+	// then: the file has been overwritten and has a newer mod time
+	assert.NoError(t, err)
+	assert.FileExists(t, filepath.Join(temp, aid))
+	s, err = os.Stat(filepath.Join(temp, aid))
+	modTimeNew := s.ModTime()
+	assert.Greater(t, modTimeNew, modTimeOld)
+
+	// given: output folder that is actually a file
+	fileNoDir := filepath.Join(temp, "file.txt")
+	_ = os.WriteFile(fileNoDir, []byte("text"), 0660)
+	// when: fetching to output folder
+	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, fileNoDir)
+	// then: an error is returned
+	assert.Error(t, err)
 }

--- a/internal/app/cli/fetch_test.go
+++ b/internal/app/cli/fetch_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/remotes"
@@ -65,6 +66,7 @@ func TestFetchExecutor_Fetch_To_OutputFolder(t *testing.T) {
 	modTimeOld := s.ModTime()
 
 	// when: fetching again the ID to same output folder
+	time.Sleep(time.Millisecond * 200)
 	err = e.Fetch(remotes.NewRemoteSpec("remote"), tmid, temp)
 	// then: the file has been overwritten and has a newer mod time
 	assert.NoError(t, err)


### PR DESCRIPTION
Changes:
+ CLI command fetch with --output now accepts only a target folder and saves the TM automatically by its given tree structure