### PR TITLE
fix: propagate repository access errors on list, versions etc. to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - handle timestamp collisions on push by retrying after one second, forcing generation of new id, or reporting the error if all else fails
+- Display errors when accessing remotes for list/verions instead of silently ignoring them
 
 ## [v0.0.0-alpha.4]
 

--- a/api/tm-catalog.openapi.yaml
+++ b/api/tm-catalog.openapi.yaml
@@ -91,6 +91,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Upstream repository error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /inventory/{name}:
     get:
       tags:

--- a/cmd/completion/complete.go
+++ b/cmd/completion/complete.go
@@ -43,15 +43,12 @@ func CompleteFetchNames(cmd *cobra.Command, args []string, toComplete string) ([
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	fns, err := rs.ListCompletions(remotes.CompletionKindFetchNames, toComplete)
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
-	}
+	fns := rs.ListCompletions(remotes.CompletionKindFetchNames, toComplete)
 	return fns, cobra.ShellCompDirectiveNoFileComp
 
 }
 
-func getRemote(cmd *cobra.Command) (remotes.Remote, error) {
+func getRemote(cmd *cobra.Command) (*remotes.Union, error) {
 	remoteName := cmd.Flag("remote").Value.String()
 	dirName := cmd.Flag("directory").Value.String()
 
@@ -60,11 +57,11 @@ func getRemote(cmd *cobra.Command) (remotes.Remote, error) {
 		return nil, err
 	}
 
-	rs, err := remotes.GetSpecdOrAll(remotes.DefaultManager(), spec)
+	u, err := remotes.GetSpecdOrAll(remotes.DefaultManager(), spec)
 	if err != nil {
 		return nil, err
 	}
-	return rs, nil
+	return u, nil
 }
 func CompleteTMNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	rs, err := getRemote(cmd)
@@ -72,9 +69,6 @@ func CompleteTMNames(cmd *cobra.Command, args []string, toComplete string) ([]st
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	cs, err := rs.ListCompletions(remotes.CompletionKindNames, toComplete)
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
-	}
+	cs := rs.ListCompletions(remotes.CompletionKindNames, toComplete)
 	return cs, cobra.ShellCompDirectiveNoFileComp
 }

--- a/internal/app/cli/common.go
+++ b/internal/app/cli/common.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/web-of-things-open-source/tm-catalog-cli/internal/model"
+	"github.com/web-of-things-open-source/tm-catalog-cli/internal/remotes"
 )
 
 const DefaultListSeparator = ","
@@ -54,4 +55,14 @@ func CreateSearchParamsFromCLI(flags FilterFlags, name string) *model.SearchPara
 		search.Options.NameFilterType = model.PrefixMatch
 	}
 	return search
+}
+
+func printErrs(hdr string, errs []remotes.RepoAccessError) {
+	if len(errs) == 0 {
+		return
+	}
+	Stderrf("%s\n", hdr)
+	for _, e := range errs {
+		Stderrf("%v\n", e)
+	}
 }

--- a/internal/app/cli/common.go
+++ b/internal/app/cli/common.go
@@ -57,12 +57,12 @@ func CreateSearchParamsFromCLI(flags FilterFlags, name string) *model.SearchPara
 	return search
 }
 
-func printErrs(hdr string, errs []remotes.RepoAccessError) {
+func printErrs(hdr string, errs []*remotes.RepoAccessError) {
 	if len(errs) == 0 {
 		return
 	}
-	Stderrf("%s\n", hdr)
+	Stderrf("%s", hdr)
 	for _, e := range errs {
-		Stderrf("%v\n", e)
+		Stderrf("%v", e)
 	}
 }

--- a/internal/app/cli/fetch.go
+++ b/internal/app/cli/fetch.go
@@ -23,11 +23,13 @@ func NewFetchExecutor(rm remotes.RemoteManager) *FetchExecutor {
 
 func (e *FetchExecutor) Fetch(remote remotes.RepoSpec, idOrName, outputPath string) error {
 
-	id, thing, err := commands.NewFetchCommand(e.rm).FetchByTMIDOrName(remote, idOrName)
+	id, thing, err, errs := commands.NewFetchCommand(e.rm).FetchByTMIDOrName(remote, idOrName)
 	if err != nil {
 		Stderrf("Could not fetch from remote: %v", err)
 		return err
 	}
+	printErrs("Errors occurred while fetching:", errs)
+
 	thing = utils.ConvertToNativeLineEndings(thing)
 
 	if outputPath == "" {

--- a/internal/app/cli/fetch.go
+++ b/internal/app/cli/fetch.go
@@ -28,7 +28,7 @@ func (e *FetchExecutor) Fetch(remote remotes.RepoSpec, idOrName, outputPath stri
 		Stderrf("Could not fetch from remote: %v", err)
 		return err
 	}
-	printErrs("Errors occurred while fetching:", errs)
+	defer printErrs("Errors occurred while fetching:", errs)
 
 	thing = utils.ConvertToNativeLineEndings(thing)
 

--- a/internal/app/cli/list.go
+++ b/internal/app/cli/list.go
@@ -21,9 +21,9 @@ func List(remote remotes.RepoSpec, search *model.SearchParams) error {
 		Stderrf("Error listing: %v", err)
 		return err
 	}
-	printErrs("Errors occurred while listing:", errs)
 
 	printToC(toc)
+	printErrs("Errors occurred while listing:", errs)
 	return nil
 }
 

--- a/internal/app/cli/list.go
+++ b/internal/app/cli/list.go
@@ -16,11 +16,13 @@ const columnWidthName = "TMC_COLUMNWIDTH"
 const columnWidthDefault = 40
 
 func List(remote remotes.RepoSpec, search *model.SearchParams) error {
-	toc, err := commands.NewListCommand(remotes.DefaultManager()).List(remote, search)
+	toc, err, errs := commands.NewListCommand(remotes.DefaultManager()).List(remote, search)
 	if err != nil {
 		Stderrf("Error listing: %v", err)
 		return err
 	}
+	printErrs("Errors occurred while listing:", errs)
+
 	printToC(toc)
 	return nil
 }

--- a/internal/app/cli/pull.go
+++ b/internal/app/cli/pull.go
@@ -62,10 +62,18 @@ func (e *PullExecutor) Pull(remote remotes.RepoSpec, search *model.SearchParams,
 		return errors.New("output target folder --output is not a folder")
 	}
 
-	searchResult, err := commands.NewListCommand(e.rm).List(remote, search)
+	searchResult, err, errs := commands.NewListCommand(e.rm).List(remote, search)
 	if err != nil {
 		Stderrf("Error listing: %v", err)
 		return err
+	}
+
+	if len(errs) > 0 {
+		fmt.Println("Errors occurred while listing TMs for pull:")
+		for _, e := range errs {
+			fmt.Println(e)
+		}
+		fmt.Println()
 	}
 
 	fmt.Printf("Pulling %d ThingModels ...\n", len(searchResult.Entries))
@@ -91,10 +99,13 @@ func (e *PullExecutor) Pull(remote remotes.RepoSpec, search *model.SearchParams,
 
 func (e *PullExecutor) pullThingModel(fc *commands.FetchCommand, outputPath string, version model.FoundVersion) (PullResult, error) {
 	spec := remotes.NewSpecFromFoundSource(version.FoundIn)
-	id, thing, err := fc.FetchByTMID(spec, version.TMID)
+	id, thing, err, errs := fc.FetchByTMID(spec, version.TMID)
+	if err == nil && len(errs) > 0 { // spec cannot be empty, therefore, there can be at most one RepoAccessError
+		err = errs[0]
+	}
 	if err != nil {
 		Stderrf("Error fetch %s: %v", version.TMID, err)
-		return PullResult{PullErr, version.TMID, fmt.Sprintf("(cannot fetch from remote %s)", spec.ToFoundSource())}, err
+		return PullResult{PullErr, version.TMID, fmt.Sprintf("(cannot fetch from remote %s)", version.FoundIn)}, err
 	}
 	thing = utils.ConvertToNativeLineEndings(thing)
 

--- a/internal/app/cli/pull.go
+++ b/internal/app/cli/pull.go
@@ -68,8 +68,6 @@ func (e *PullExecutor) Pull(remote remotes.RepoSpec, search *model.SearchParams,
 		return err
 	}
 
-	printErrs("Errors occurred while listing TMs for pull:", errs)
-
 	fmt.Printf("Pulling %d ThingModels ...\n", len(searchResult.Entries))
 
 	fc := commands.NewFetchCommand(e.rm)
@@ -87,6 +85,7 @@ func (e *PullExecutor) Pull(remote remotes.RepoSpec, search *model.SearchParams,
 	for _, res := range totalRes {
 		fmt.Println(res)
 	}
+	printErrs("Errors occurred while listing TMs for pull:", errs)
 
 	return err
 }

--- a/internal/app/cli/pull.go
+++ b/internal/app/cli/pull.go
@@ -68,13 +68,7 @@ func (e *PullExecutor) Pull(remote remotes.RepoSpec, search *model.SearchParams,
 		return err
 	}
 
-	if len(errs) > 0 {
-		fmt.Println("Errors occurred while listing TMs for pull:")
-		for _, e := range errs {
-			fmt.Println(e)
-		}
-		fmt.Println()
-	}
+	printErrs("Errors occurred while listing TMs for pull:", errs)
 
 	fmt.Printf("Pulling %d ThingModels ...\n", len(searchResult.Entries))
 

--- a/internal/app/cli/pull_test.go
+++ b/internal/app/cli/pull_test.go
@@ -111,7 +111,9 @@ func TestPullExecutor_pullThingModel(t *testing.T) {
 	// given: a RemoteManager and a Remote
 	rm := remotes.NewMockRemoteManager(t)
 	r := remotes.NewMockRemote(t)
-	rm.On("Get", remotes.NewRemoteSpec("r1")).Return(r, nil)
+	spec := remotes.NewRemoteSpec("r1")
+	rm.On("Get", spec).Return(r, nil)
+	r.On("Spec").Return(spec)
 
 	fc := commands.NewFetchCommand(rm)
 	tmID := listResult.Entries[0].Versions[0].TMID

--- a/internal/app/cli/versions.go
+++ b/internal/app/cli/versions.go
@@ -11,12 +11,12 @@ import (
 )
 
 func ListVersions(spec remotes.RepoSpec, name string) error {
-	tocVersions, err := commands.NewVersionsCommand(remotes.DefaultManager()).ListVersions(spec, name)
+	tocVersions, err, errs := commands.NewVersionsCommand(remotes.DefaultManager()).ListVersions(spec, name)
 	if err != nil {
 		Stderrf("Could not list versions of %s: %v", name, err)
 		return err
 	}
-
+	printErrs("Errors occurred while listing versions:", errs)
 	printToCThing(name, tocVersions)
 	return nil
 }

--- a/internal/app/cli/versions.go
+++ b/internal/app/cli/versions.go
@@ -16,8 +16,8 @@ func ListVersions(spec remotes.RepoSpec, name string) error {
 		Stderrf("Could not list versions of %s: %v", name, err)
 		return err
 	}
-	printErrs("Errors occurred while listing versions:", errs)
 	printToCThing(name, tocVersions)
+	printErrs("Errors occurred while listing versions:", errs)
 	return nil
 }
 

--- a/internal/app/http/common.go
+++ b/internal/app/http/common.go
@@ -22,6 +22,8 @@ const (
 	error503Title  = "Service Unavailable"
 	error500Title  = "Internal Server Error"
 	error500Detail = "An unhandled error has occurred. Try again later. If it is a bug we already recorded it. Retrying will most likely not help"
+	error502Title  = "Bad Gateway"
+	error502Detail = "An upstream Thing Model repository returned an error"
 
 	headerContentType         = "Content-Type"
 	headerCacheControl        = "Cache-Control"
@@ -76,6 +78,7 @@ func HandleErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
 	errCode := ""
 
 	var eErr *remotes.ErrTMIDConflict
+	var aErr *remotes.RepoAccessError
 	var bErr *BaseHttpError
 	if errors.Is(err, remotes.ErrTmNotFound) {
 		errTitle = error404Title
@@ -89,6 +92,10 @@ func HandleErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
 		errTitle = bErr.Title
 		errDetail = bErr.Detail
 		errStatus = bErr.Status
+	} else if errors.As(err, &aErr) {
+		errTitle = error502Title
+		errDetail = error502Detail
+		errStatus = http.StatusBadGateway
 	} else if errors.As(err, &eErr) {
 		errTitle = error409Title
 		errDetail = eErr.Error()

--- a/internal/app/http/server.go
+++ b/internal/app/http/server.go
@@ -18,8 +18,8 @@ import (
 //          e.g. r.HandleFunc(options.BaseURL+"/inventory/{name:.+}/.versions" should be on top of r.HandleFunc(options.BaseURL+"/inventory/{name:.+}
 // 3. when 2. is done, comment lines "// //go:generate" again, to prevent unwanted changes by calling "go generate"
 
-// //go:generate go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@v2.0.0 -package server -generate types -o server/models.gen.go ../../../api/tm-catalog.openapi.yaml
-// //go:generate go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@v2.0.0 -package server -generate gorilla-server -o server/server.gen.go ../../../api/tm-catalog.openapi.yaml
+//go:generate go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@v2.0.0 -package server -generate types -o server/models.gen.go ../../../api/tm-catalog.openapi.yaml
+//go:generate go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@v2.0.0 -package server -generate gorilla-server -o server/server.gen.go ../../../api/tm-catalog.openapi.yaml
 
 type ServerOptions struct {
 	CORS CORSOptions

--- a/internal/app/http/server.go
+++ b/internal/app/http/server.go
@@ -18,8 +18,8 @@ import (
 //          e.g. r.HandleFunc(options.BaseURL+"/inventory/{name:.+}/.versions" should be on top of r.HandleFunc(options.BaseURL+"/inventory/{name:.+}
 // 3. when 2. is done, comment lines "// //go:generate" again, to prevent unwanted changes by calling "go generate"
 
-//go:generate go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@v2.0.0 -package server -generate types -o server/models.gen.go ../../../api/tm-catalog.openapi.yaml
-//go:generate go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@v2.0.0 -package server -generate gorilla-server -o server/server.gen.go ../../../api/tm-catalog.openapi.yaml
+// //go:generate go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@v2.0.0 -package server -generate types -o server/models.gen.go ../../../api/tm-catalog.openapi.yaml
+// //go:generate go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@v2.0.0 -package server -generate gorilla-server -o server/server.gen.go ../../../api/tm-catalog.openapi.yaml
 
 type ServerOptions struct {
 	CORS CORSOptions

--- a/internal/app/http/service.go
+++ b/internal/app/http/service.go
@@ -47,7 +47,7 @@ func NewDefaultHandlerService(rm remotes.RemoteManager, servedRepo remotes.RepoS
 
 func (dhs *defaultHandlerService) ListInventory(ctx context.Context, search *model.SearchParams) (*model.SearchResult, error) {
 	c := commands.NewListCommand(dhs.remoteManager)
-	toc, err := c.List(dhs.serveRemote, search)
+	toc, err, _ := c.List(dhs.serveRemote, search)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (dhs *defaultHandlerService) FetchThingModel(ctx context.Context, tmID stri
 	}
 
 	rm := dhs.remoteManager
-	_, data, err := commands.NewFetchCommand(rm).FetchByTMIDOrName(dhs.serveRemote, tmID)
+	_, data, err, _ := commands.NewFetchCommand(rm).FetchByTMIDOrName(dhs.serveRemote, tmID)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (dhs *defaultHandlerService) GetCompletions(ctx context.Context, kind, toCo
 	if err != nil {
 		return nil, err
 	}
-	return rs.ListCompletions(kind, toComplete)
+	return rs.ListCompletions(kind, toComplete), nil
 }
 
 func (dhs *defaultHandlerService) CheckHealth(ctx context.Context) error {

--- a/internal/app/http/service.go
+++ b/internal/app/http/service.go
@@ -47,9 +47,13 @@ func NewDefaultHandlerService(rm remotes.RemoteManager, servedRepo remotes.RepoS
 
 func (dhs *defaultHandlerService) ListInventory(ctx context.Context, search *model.SearchParams) (*model.SearchResult, error) {
 	c := commands.NewListCommand(dhs.remoteManager)
-	toc, err, _ := c.List(dhs.serveRemote, search)
+	toc, err, errs := c.List(dhs.serveRemote, search)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(errs) > 0 {
+		return nil, errs[0]
 	}
 
 	return &toc, nil

--- a/internal/commands/fetch.go
+++ b/internal/commands/fetch.go
@@ -72,7 +72,7 @@ func ParseAsTMIDOrFetchName(idOrName string) (*model.TMID, *FetchName, error) {
 	return nil, nil, err
 }
 
-func (c *FetchCommand) FetchByTMIDOrName(spec remotes.RepoSpec, idOrName string) (string, []byte, error, []remotes.RepoAccessError) {
+func (c *FetchCommand) FetchByTMIDOrName(spec remotes.RepoSpec, idOrName string) (string, []byte, error, []*remotes.RepoAccessError) {
 	tmid, fn, err := ParseAsTMIDOrFetchName(idOrName)
 	if err != nil {
 		return "", nil, err, nil
@@ -83,7 +83,7 @@ func (c *FetchCommand) FetchByTMIDOrName(spec remotes.RepoSpec, idOrName string)
 	return c.FetchByName(spec, *fn)
 }
 
-func (c *FetchCommand) FetchByTMID(spec remotes.RepoSpec, tmid string) (string, []byte, error, []remotes.RepoAccessError) {
+func (c *FetchCommand) FetchByTMID(spec remotes.RepoSpec, tmid string) (string, []byte, error, []*remotes.RepoAccessError) {
 	rs, err := remotes.GetSpecdOrAll(c.remoteMgr, spec)
 	if err != nil {
 		return "", nil, err, nil
@@ -91,7 +91,7 @@ func (c *FetchCommand) FetchByTMID(spec remotes.RepoSpec, tmid string) (string, 
 
 	return rs.Fetch(tmid)
 }
-func (c *FetchCommand) FetchByName(spec remotes.RepoSpec, fn FetchName) (string, []byte, error, []remotes.RepoAccessError) {
+func (c *FetchCommand) FetchByName(spec remotes.RepoSpec, fn FetchName) (string, []byte, error, []*remotes.RepoAccessError) {
 	log := slog.Default()
 	tocVersions, err, errs := NewVersionsCommand(c.remoteMgr).ListVersions(spec, fn.Name)
 	if err != nil {

--- a/internal/commands/fetch_test.go
+++ b/internal/commands/fetch_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -90,7 +91,7 @@ func TestFetchCommand_FetchByTMIDOrName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, b, err := f.FetchByTMIDOrName(remotes.EmptySpec, test.in)
+		_, b, err, _ := f.FetchByTMIDOrName(remotes.EmptySpec, test.in)
 		if test.expErr != nil {
 			assert.ErrorIs(t, err, test.expErr, "Expected error in FetchByTMIDOrName(%s)", test.in)
 			assert.ErrorContains(t, err, test.expErrText, "Unexpected error in FetchByTMIDOrName(%s)", test.in)
@@ -230,50 +231,141 @@ func TestFetchCommand_FetchByTMIDOrName_MultipleRemotes(t *testing.T) {
 	var b []byte
 	var err error
 	t.Run("fetch from unspecified by id", func(t *testing.T) {
-		id, b, err = f.FetchByTMIDOrName(remotes.EmptySpec, "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json")
+		id, b, err, _ = f.FetchByTMIDOrName(remotes.EmptySpec, "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json")
 		assert.NoError(t, err)
 		assert.Equal(t, "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json", id)
 		assert.True(t, bytes.Contains(b, []byte("r1")))
 
-		id, b, err = f.FetchByTMIDOrName(remotes.EmptySpec, "author/manufacturer/mpn/v1.0.0-20231205123243-c49617d2e4fc.tm.json")
+		id, b, err, _ = f.FetchByTMIDOrName(remotes.EmptySpec, "author/manufacturer/mpn/v1.0.0-20231205123243-c49617d2e4fc.tm.json")
 		assert.NoError(t, err)
 		assert.Equal(t, "author/manufacturer/mpn/v1.0.0-20231205123243-c49617d2e4fc.tm.json", id)
 		assert.True(t, bytes.Contains(b, []byte("r2")))
 	})
 	t.Run("fetch from named by id", func(t *testing.T) {
-		id, b, err = f.FetchByTMIDOrName(remotes.NewRemoteSpec("r1"), "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json")
+		id, b, err, _ = f.FetchByTMIDOrName(remotes.NewRemoteSpec("r1"), "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json")
 		assert.NoError(t, err)
 		assert.Equal(t, "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json", id)
 		assert.True(t, bytes.Contains(b, []byte("r1")))
 
-		id, b, err = f.FetchByTMIDOrName(remotes.NewRemoteSpec("r1"), "author/manufacturer/mpn/v1.0.0-20231205123243-c49617d2e4fc.tm.json")
+		id, b, err, _ = f.FetchByTMIDOrName(remotes.NewRemoteSpec("r1"), "author/manufacturer/mpn/v1.0.0-20231205123243-c49617d2e4fc.tm.json")
 		assert.Error(t, err)
 
-		id, b, err = f.FetchByTMIDOrName(remotes.NewRemoteSpec("r2"), "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json")
+		id, b, err, _ = f.FetchByTMIDOrName(remotes.NewRemoteSpec("r2"), "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json")
 		assert.Error(t, err)
 
-		id, b, err = f.FetchByTMIDOrName(remotes.NewRemoteSpec("r2"), "author/manufacturer/mpn/v1.0.0-20231205123243-c49617d2e4fc.tm.json")
+		id, b, err, _ = f.FetchByTMIDOrName(remotes.NewRemoteSpec("r2"), "author/manufacturer/mpn/v1.0.0-20231205123243-c49617d2e4fc.tm.json")
 		assert.NoError(t, err)
 		assert.Equal(t, "author/manufacturer/mpn/v1.0.0-20231205123243-c49617d2e4fc.tm.json", id)
 		assert.True(t, bytes.Contains(b, []byte("r2")))
 	})
 	t.Run("fetch from unspecified by name", func(t *testing.T) {
-		id, b, err = f.FetchByTMIDOrName(remotes.EmptySpec, "author/manufacturer/mpn")
+		id, b, err, _ = f.FetchByTMIDOrName(remotes.EmptySpec, "author/manufacturer/mpn")
 		assert.NoError(t, err)
 		assert.Equal(t, "author/manufacturer/mpn/v1.0.0-20231205123243-c49617d2e4fc.tm.json", id)
 		assert.True(t, bytes.Contains(b, []byte("r2")))
 
 	})
 	t.Run("fetch from named by name", func(t *testing.T) {
-		id, b, err = f.FetchByTMIDOrName(remotes.NewRemoteSpec("r1"), "author/manufacturer/mpn")
+		id, b, err, _ = f.FetchByTMIDOrName(remotes.NewRemoteSpec("r1"), "author/manufacturer/mpn")
 		assert.NoError(t, err)
 		assert.Equal(t, "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json", id)
 		assert.True(t, bytes.Contains(b, []byte("r1")))
 
-		id, b, err = f.FetchByTMIDOrName(remotes.NewRemoteSpec("r2"), "author/manufacturer/mpn")
+		id, b, err, _ = f.FetchByTMIDOrName(remotes.NewRemoteSpec("r2"), "author/manufacturer/mpn")
 		assert.NoError(t, err)
 		assert.Equal(t, "author/manufacturer/mpn/v1.0.0-20231205123243-c49617d2e4fc.tm.json", id)
 		assert.True(t, bytes.Contains(b, []byte("r2")))
 
+	})
+}
+
+func TestFetchCommand_FetchByTMID(t *testing.T) {
+	rm := remotes.NewMockRemoteManager(t)
+	r1 := remotes.NewMockRemote(t)
+	r2 := remotes.NewMockRemote(t)
+	r1.On("Spec").Return(remotes.NewRemoteSpec("r1"))
+	rm.On("All").Return([]remotes.Remote{r1, r2}, nil)
+
+	t.Run("success with unexpected error", func(t *testing.T) {
+		r1.On("Fetch", "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json").Return("", nil, errors.New("unexpected")).Once()
+		r2.On("Fetch", "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json").Return("author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json", []byte("{\"src\": \"r2\"}"), nil).Once()
+		f := NewFetchCommand(rm)
+		id, b, err, errs := f.FetchByTMID(remotes.EmptySpec, "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json")
+		assert.NoError(t, err)
+		assert.Len(t, errs, 0)
+		assert.Equal(t, "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json", id)
+		assert.True(t, bytes.Contains(b, []byte("r2")))
+
+	})
+
+	t.Run("not found with unexpected error", func(t *testing.T) {
+		r1.On("Fetch", "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json").Return("", nil, errors.New("unexpected")).Once()
+		r2.On("Fetch", "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json").Return("", nil, remotes.ErrTmNotFound).Once()
+		f := NewFetchCommand(rm)
+		_, _, err, errs := f.FetchByTMID(remotes.EmptySpec, "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json")
+		assert.ErrorIs(t, err, remotes.ErrTmNotFound)
+		if assert.Len(t, errs, 1) {
+			assert.ErrorContains(t, errs[0], "unexpected")
+		}
+	})
+
+}
+
+func TestFetchCommand_FetchByName(t *testing.T) {
+	rm := remotes.NewMockRemoteManager(t)
+	r1 := remotes.NewMockRemote(t)
+	r2 := remotes.NewMockRemote(t)
+	rm.On("All").Return([]remotes.Remote{r1, r2}, nil)
+	r1Spec := remotes.NewRemoteSpec("r1")
+	rm.On("Get", r1Spec).Return(r1, nil)
+	r1.On("Spec").Return(r1Spec)
+	r2Spec := remotes.NewRemoteSpec("r2")
+	//rm.On("Get", r2Spec).Return(r2, nil)
+	r2.On("Spec").Return(r2Spec)
+
+	t.Run("name found", func(t *testing.T) {
+
+		r1.On("Fetch", "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json").Return("author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json", []byte("{\"src\": \"r1\"}"), nil)
+		r1.On("Versions", "author/manufacturer/mpn").Return([]model.FoundVersion{
+			{
+				TOCVersion: model.TOCVersion{
+					Version:   model.Version{Model: "v1.0.0"},
+					TMID:      "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json",
+					Digest:    "a49617d2e4fc",
+					TimeStamp: "20231005123243",
+				},
+				FoundIn: model.FoundSource{RemoteName: "r1"},
+			},
+		}, nil)
+		r2.On("Versions", "author/manufacturer/mpn").Return(nil, errors.New("unexpected"))
+
+		f := NewFetchCommand(rm)
+		t.Run("fetch from unspecified by name", func(t *testing.T) {
+			id, b, err, errs := f.FetchByName(remotes.EmptySpec, FetchName{Name: "author/manufacturer/mpn"})
+			assert.NoError(t, err)
+			if assert.Len(t, errs, 1) {
+				assert.ErrorContains(t, errs[0], "unexpected")
+			}
+			assert.Equal(t, "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json", id)
+			assert.True(t, bytes.Contains(b, []byte("r1")))
+
+		})
+	})
+	t.Run("name not found", func(t *testing.T) {
+
+		//r1.On("Fetch", "author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json").Return("author/manufacturer/mpn/v1.0.0-20231005123243-a49617d2e4fc.tm.json", []byte("{\"src\": \"r1\"}"), nil)
+		r1.On("Versions", "author/manufacturer/mpn2").Return(nil, errors.New("unexpected1"))
+		r2.On("Versions", "author/manufacturer/mpn2").Return(nil, errors.New("unexpected2"))
+
+		f := NewFetchCommand(rm)
+		t.Run("fetch from unspecified by name", func(t *testing.T) {
+			_, _, err, errs := f.FetchByName(remotes.EmptySpec, FetchName{Name: "author/manufacturer/mpn2"})
+			assert.ErrorIs(t, err, remotes.ErrTmNotFound)
+			if assert.Len(t, errs, 2) {
+				assert.ErrorContains(t, errs[0], "unexpected1")
+				assert.ErrorContains(t, errs[1], "unexpected2")
+			}
+
+		})
 	})
 }

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -14,7 +14,7 @@ func NewListCommand(m remotes.RemoteManager) *ListCommand {
 		remoteMgr: m,
 	}
 }
-func (c *ListCommand) List(rSpec remotes.RepoSpec, search *model.SearchParams) (model.SearchResult, error, []remotes.RepoAccessError) {
+func (c *ListCommand) List(rSpec remotes.RepoSpec, search *model.SearchParams) (model.SearchResult, error, []*remotes.RepoAccessError) {
 	rs, err := remotes.GetSpecdOrAll(c.remoteMgr, rSpec)
 	if err != nil {
 		return model.SearchResult{}, err, nil

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -14,10 +14,11 @@ func NewListCommand(m remotes.RemoteManager) *ListCommand {
 		remoteMgr: m,
 	}
 }
-func (c *ListCommand) List(rSpec remotes.RepoSpec, search *model.SearchParams) (model.SearchResult, error) {
+func (c *ListCommand) List(rSpec remotes.RepoSpec, search *model.SearchParams) (model.SearchResult, error, []remotes.RepoAccessError) {
 	rs, err := remotes.GetSpecdOrAll(c.remoteMgr, rSpec)
 	if err != nil {
-		return model.SearchResult{}, err
+		return model.SearchResult{}, err, nil
 	}
-	return rs.List(search)
+	sr, errs := rs.List(search)
+	return sr, nil, errs
 }

--- a/internal/commands/list_test.go
+++ b/internal/commands/list_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,49 +10,87 @@ import (
 )
 
 func TestListCommand_List(t *testing.T) {
-	rm := remotes.NewMockRemoteManager(t)
-	r1 := remotes.NewMockRemote(t)
-	r2 := remotes.NewMockRemote(t)
-	rm.On("All").Return([]remotes.Remote{r1, r2}, nil)
-	r1.On("List", &model.SearchParams{Query: "omnicorp"}).Return(model.SearchResult{
-		Entries: []model.FoundEntry{
-			{
-				Name:         "omnicorp/senseall",
-				Manufacturer: model.SchemaManufacturer{Name: "omnicorp"},
-				Mpn:          "senseall",
-				Author:       model.SchemaAuthor{Name: "omnicorp"},
+	t.Run("merged", func(t *testing.T) {
+		rm := remotes.NewMockRemoteManager(t)
+		r1 := remotes.NewMockRemote(t)
+		r2 := remotes.NewMockRemote(t)
+		rm.On("All").Return([]remotes.Remote{r1, r2}, nil)
+		r1.On("List", &model.SearchParams{Query: "omnicorp"}).Return(model.SearchResult{
+			Entries: []model.FoundEntry{
+				{
+					Name:         "omnicorp/senseall",
+					Manufacturer: model.SchemaManufacturer{Name: "omnicorp"},
+					Mpn:          "senseall",
+					Author:       model.SchemaAuthor{Name: "omnicorp"},
+				},
+				{
+					Name:         "omnicorp/lightall",
+					Manufacturer: model.SchemaManufacturer{Name: "omnicorp"},
+					Mpn:          "lightall",
+					Author:       model.SchemaAuthor{Name: "omnicorp"},
+				},
 			},
-			{
-				Name:         "omnicorp/lightall",
-				Manufacturer: model.SchemaManufacturer{Name: "omnicorp"},
-				Mpn:          "lightall",
-				Author:       model.SchemaAuthor{Name: "omnicorp"},
+		}, nil)
+		r2.On("List", &model.SearchParams{Query: "omnicorp"}).Return(model.SearchResult{
+			Entries: []model.FoundEntry{
+				{
+					Name:         "omnicorp/senseall",
+					Manufacturer: model.SchemaManufacturer{Name: "omnicorp"},
+					Mpn:          "senseall",
+					Author:       model.SchemaAuthor{Name: "omnicorp"},
+				},
+				{
+					Name:         "omnicorp/actall",
+					Manufacturer: model.SchemaManufacturer{Name: "omnicorp"},
+					Mpn:          "actall",
+					Author:       model.SchemaAuthor{Name: "omnicorp"},
+				},
 			},
-		},
-	}, nil)
-	r2.On("List", &model.SearchParams{Query: "omnicorp"}).Return(model.SearchResult{
-		Entries: []model.FoundEntry{
-			{
-				Name:         "omnicorp/senseall",
-				Manufacturer: model.SchemaManufacturer{Name: "omnicorp"},
-				Mpn:          "senseall",
-				Author:       model.SchemaAuthor{Name: "omnicorp"},
-			},
-			{
-				Name:         "omnicorp/actall",
-				Manufacturer: model.SchemaManufacturer{Name: "omnicorp"},
-				Mpn:          "actall",
-				Author:       model.SchemaAuthor{Name: "omnicorp"},
-			},
-		},
-	}, nil)
+		}, nil)
 
-	c := NewListCommand(rm)
-	res, err := c.List(remotes.EmptySpec, &model.SearchParams{Query: "omnicorp"})
+		c := NewListCommand(rm)
+		res, err, _ := c.List(remotes.EmptySpec, &model.SearchParams{Query: "omnicorp"})
 
-	assert.NoError(t, err)
-	assert.Len(t, res.Entries, 3)
-	assert.Equal(t, "omnicorp/actall", res.Entries[0].Name)
-	assert.Equal(t, "omnicorp/lightall", res.Entries[1].Name)
-	assert.Equal(t, "omnicorp/senseall", res.Entries[2].Name)
+		assert.NoError(t, err)
+		assert.Len(t, res.Entries, 3)
+		assert.Equal(t, "omnicorp/actall", res.Entries[0].Name)
+		assert.Equal(t, "omnicorp/lightall", res.Entries[1].Name)
+		assert.Equal(t, "omnicorp/senseall", res.Entries[2].Name)
+	})
+	t.Run("one error", func(t *testing.T) {
+		rm := remotes.NewMockRemoteManager(t)
+		r1 := remotes.NewMockRemote(t)
+		r2 := remotes.NewMockRemote(t)
+		r2.On("Spec").Return(remotes.NewRemoteSpec("r2"))
+		rm.On("All").Return([]remotes.Remote{r1, r2}, nil)
+		r1.On("List", &model.SearchParams{Query: "omnicorp"}).Return(model.SearchResult{
+			Entries: []model.FoundEntry{
+				{
+					Name:         "omnicorp/senseall",
+					Manufacturer: model.SchemaManufacturer{Name: "omnicorp"},
+					Mpn:          "senseall",
+					Author:       model.SchemaAuthor{Name: "omnicorp"},
+				},
+				{
+					Name:         "omnicorp/lightall",
+					Manufacturer: model.SchemaManufacturer{Name: "omnicorp"},
+					Mpn:          "lightall",
+					Author:       model.SchemaAuthor{Name: "omnicorp"},
+				},
+			},
+		}, nil)
+		r2.On("List", &model.SearchParams{Query: "omnicorp"}).Return(model.SearchResult{}, errors.New("unexpected error"))
+
+		c := NewListCommand(rm)
+		res, err, errs := c.List(remotes.EmptySpec, &model.SearchParams{Query: "omnicorp"})
+
+		assert.NoError(t, err)
+		if assert.Len(t, errs, 1) {
+			assert.ErrorContains(t, errs[0], "unexpected error")
+		}
+		assert.Len(t, res.Entries, 2)
+		assert.Equal(t, "omnicorp/lightall", res.Entries[0].Name)
+		assert.Equal(t, "omnicorp/senseall", res.Entries[1].Name)
+	})
+
 }

--- a/internal/commands/versions.go
+++ b/internal/commands/versions.go
@@ -14,7 +14,7 @@ func NewVersionsCommand(manager remotes.RemoteManager) *VersionsCommand {
 		remoteMgr: manager,
 	}
 }
-func (c *VersionsCommand) ListVersions(spec remotes.RepoSpec, name string) ([]model.FoundVersion, error, []remotes.RepoAccessError) {
+func (c *VersionsCommand) ListVersions(spec remotes.RepoSpec, name string) ([]model.FoundVersion, error, []*remotes.RepoAccessError) {
 	rs, err := remotes.GetSpecdOrAll(c.remoteMgr, spec)
 	if err != nil {
 		return nil, err, nil

--- a/internal/commands/versions.go
+++ b/internal/commands/versions.go
@@ -14,10 +14,11 @@ func NewVersionsCommand(manager remotes.RemoteManager) *VersionsCommand {
 		remoteMgr: manager,
 	}
 }
-func (c *VersionsCommand) ListVersions(spec remotes.RepoSpec, name string) ([]model.FoundVersion, error) {
+func (c *VersionsCommand) ListVersions(spec remotes.RepoSpec, name string) ([]model.FoundVersion, error, []remotes.RepoAccessError) {
 	rs, err := remotes.GetSpecdOrAll(c.remoteMgr, spec)
 	if err != nil {
-		return nil, err
+		return nil, err, nil
 	}
-	return rs.Versions(name)
+	versions, errors := rs.Versions(name)
+	return versions, nil, errors
 }

--- a/internal/commands/versions_test.go
+++ b/internal/commands/versions_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,57 +10,106 @@ import (
 )
 
 func TestVersionsCommand_ListVersions(t *testing.T) {
-	rm := remotes.NewMockRemoteManager(t)
-	r1 := remotes.NewMockRemote(t)
-	r2 := remotes.NewMockRemote(t)
-	rm.On("All").Return([]remotes.Remote{r1, r2}, nil)
-	r1.On("Versions", "senseall").Return(
-		[]model.FoundVersion{
+
+	t.Run("merged", func(t *testing.T) {
+
+		rm := remotes.NewMockRemoteManager(t)
+		r1 := remotes.NewMockRemote(t)
+		r2 := remotes.NewMockRemote(t)
+		rm.On("All").Return([]remotes.Remote{r1, r2}, nil)
+		r1.On("Versions", "senseall").Return(
+			[]model.FoundVersion{
+				{
+					TOCVersion: model.TOCVersion{
+						TMID: "omnicorp/senseall/v0.36.0-20231231153548-243d1b462ccc.tm.json",
+					},
+					FoundIn: model.FoundSource{RemoteName: "r1"},
+				},
+				{
+					TOCVersion: model.TOCVersion{
+						TMID: "omnicorp/senseall/v0.35.0-20231230153548-243d1b462bbb.tm.json",
+					},
+					FoundIn: model.FoundSource{RemoteName: "r1"},
+				},
+			}, nil)
+		r2.On("Versions", "senseall").Return([]model.FoundVersion{
 			{
 				TOCVersion: model.TOCVersion{
-					TMID: "omnicorp/senseall/v0.36.0-20231231153548-243d1b462ccc.tm.json",
+					TMID: "omnicorp/senseall/v0.34.0-20231130153548-243d1b462aaa.tm.json",
 				},
-				FoundIn: model.FoundSource{RemoteName: "r1"},
+				FoundIn: model.FoundSource{RemoteName: "r2"},
 			},
 			{
 				TOCVersion: model.TOCVersion{
-					TMID: "omnicorp/senseall/v0.35.0-20231230153548-243d1b462bbb.tm.json",
+					TMID: "omnicorp/senseall/v0.35.0-20231230173548-243d1b462bbb.tm.json",
 				},
-				FoundIn: model.FoundSource{RemoteName: "r1"},
+				FoundIn: model.FoundSource{RemoteName: "r2"},
 			},
 		}, nil)
-	r2.On("Versions", "senseall").Return([]model.FoundVersion{
-		{
-			TOCVersion: model.TOCVersion{
-				TMID: "omnicorp/senseall/v0.34.0-20231130153548-243d1b462aaa.tm.json",
-			},
-			FoundIn: model.FoundSource{RemoteName: "r2"},
-		},
-		{
-			TOCVersion: model.TOCVersion{
-				TMID: "omnicorp/senseall/v0.35.0-20231230173548-243d1b462bbb.tm.json",
-			},
-			FoundIn: model.FoundSource{RemoteName: "r2"},
-		},
-	}, nil)
+		c := NewVersionsCommand(rm)
+		res, err, errs := c.ListVersions(remotes.EmptySpec, "senseall")
 
-	c := NewVersionsCommand(rm)
-	res, err := c.ListVersions(remotes.EmptySpec, "senseall")
+		assert.NoError(t, err)
+		assert.Len(t, errs, 0)
+		assert.Len(t, res, 3)
+		assert.Equal(t, []model.FoundVersion{
+			{
+				TOCVersion: model.TOCVersion{TMID: "omnicorp/senseall/v0.34.0-20231130153548-243d1b462aaa.tm.json"},
+				FoundIn:    model.FoundSource{RemoteName: "r2"},
+			},
+			{
+				TOCVersion: model.TOCVersion{TMID: "omnicorp/senseall/v0.35.0-20231230173548-243d1b462bbb.tm.json"},
+				FoundIn:    model.FoundSource{RemoteName: "r2"},
+			},
+			{
+				TOCVersion: model.TOCVersion{TMID: "omnicorp/senseall/v0.36.0-20231231153548-243d1b462ccc.tm.json"},
+				FoundIn:    model.FoundSource{RemoteName: "r1"},
+			},
+		}, res)
 
-	assert.NoError(t, err)
-	assert.Len(t, res, 3)
-	assert.Equal(t, []model.FoundVersion{
-		{
-			TOCVersion: model.TOCVersion{TMID: "omnicorp/senseall/v0.34.0-20231130153548-243d1b462aaa.tm.json"},
-			FoundIn:    model.FoundSource{RemoteName: "r2"},
-		},
-		{
-			TOCVersion: model.TOCVersion{TMID: "omnicorp/senseall/v0.35.0-20231230173548-243d1b462bbb.tm.json"},
-			FoundIn:    model.FoundSource{RemoteName: "r2"},
-		},
-		{
-			TOCVersion: model.TOCVersion{TMID: "omnicorp/senseall/v0.36.0-20231231153548-243d1b462ccc.tm.json"},
-			FoundIn:    model.FoundSource{RemoteName: "r1"},
-		},
-	}, res)
+	})
+
+	t.Run("one error", func(t *testing.T) {
+
+		rm := remotes.NewMockRemoteManager(t)
+		r1 := remotes.NewMockRemote(t)
+		r2 := remotes.NewMockRemote(t)
+		r2.On("Spec").Return(remotes.NewRemoteSpec("r2"))
+		rm.On("All").Return([]remotes.Remote{r1, r2}, nil)
+		r1.On("Versions", "senseall").Return(
+			[]model.FoundVersion{
+				{
+					TOCVersion: model.TOCVersion{
+						TMID: "omnicorp/senseall/v0.36.0-20231231153548-243d1b462ccc.tm.json",
+					},
+					FoundIn: model.FoundSource{RemoteName: "r1"},
+				},
+				{
+					TOCVersion: model.TOCVersion{
+						TMID: "omnicorp/senseall/v0.35.0-20231230153548-243d1b462bbb.tm.json",
+					},
+					FoundIn: model.FoundSource{RemoteName: "r1"},
+				},
+			}, nil)
+		r2.On("Versions", "senseall").Return(nil, errors.New("unexpected error"))
+		c := NewVersionsCommand(rm)
+		res, err, errs := c.ListVersions(remotes.EmptySpec, "senseall")
+		if assert.Len(t, errs, 1) {
+			assert.ErrorContains(t, errs[0], "unexpected error")
+		}
+		assert.NoError(t, err)
+		assert.Len(t, res, 2)
+		assert.Equal(t, []model.FoundVersion{
+			{
+				TOCVersion: model.TOCVersion{TMID: "omnicorp/senseall/v0.35.0-20231230153548-243d1b462bbb.tm.json"},
+				FoundIn:    model.FoundSource{RemoteName: "r1"},
+			},
+			{
+				TOCVersion: model.TOCVersion{TMID: "omnicorp/senseall/v0.36.0-20231231153548-243d1b462ccc.tm.json"},
+				FoundIn:    model.FoundSource{RemoteName: "r1"},
+			},
+		}, res)
+
+	})
+
 }

--- a/internal/remotes/remote.go
+++ b/internal/remotes/remote.go
@@ -114,7 +114,13 @@ func (r RepoSpec) ToFoundSource() model.FoundSource {
 }
 
 func (r RepoSpec) String() string {
-	return fmt.Sprintf("repository spec {dir: %s, remoteName: %s}", r.dir, r.remoteName)
+	if r.dir == "" {
+		if r.remoteName == "" {
+			return fmt.Sprintf("undefined repository")
+		}
+		return fmt.Sprintf("remote <%s>", r.remoteName)
+	}
+	return fmt.Sprintf("directory %s", r.dir)
 }
 
 var EmptySpec, _ = NewSpec("", "")

--- a/internal/remotes/remote.go
+++ b/internal/remotes/remote.go
@@ -369,17 +369,17 @@ func AsRemoteConfig(bytes []byte) (map[string]any, error) {
 }
 
 // GetSpecdOrAll returns the remote specified by spec in a slice, or all remotes, if the spec is empty
-func GetSpecdOrAll(manager RemoteManager, spec RepoSpec) (Remote, error) {
+func GetSpecdOrAll(manager RemoteManager, spec RepoSpec) (*Union, error) {
 	if spec.remoteName != "" || spec.dir != "" {
 		remote, err := manager.Get(spec)
 		if err != nil {
 			return nil, err
 		}
-		return remote, nil
+		return NewUnion(remote), nil
 	}
 	all, err := manager.All()
 	if err != nil {
 		return nil, err
 	}
-	return NewUnionRemote(all...), nil
+	return NewUnion(all...), nil
 }

--- a/internal/remotes/remote_test.go
+++ b/internal/remotes/remote_test.go
@@ -269,16 +269,16 @@ func TestGetSpecdOrAll(t *testing.T) {
 	rm.On("All").Return([]Remote{r1, r2}, nil)
 	all, err := GetSpecdOrAll(rm, EmptySpec)
 	assert.NoError(t, err)
-	assert.Equal(t, &UnionRemote{rs: []Remote{r1, r2}}, all)
+	assert.Equal(t, &Union{rs: []Remote{r1, r2}}, all)
 
 	rm.On("Get", NewRemoteSpec("r1")).Return(r1, nil)
 	all, err = GetSpecdOrAll(rm, NewRemoteSpec("r1"))
 	assert.NoError(t, err)
-	assert.Equal(t, r1, all)
+	assert.Equal(t, &Union{rs: []Remote{r1}}, all)
 
 	rm.On("Get", NewDirSpec("dir1")).Return(r3, nil)
 	all, err = GetSpecdOrAll(rm, NewDirSpec("dir1"))
 	assert.NoError(t, err)
-	assert.Equal(t, r3, all)
+	assert.Equal(t, &Union{rs: []Remote{r3}}, all)
 
 }


### PR DESCRIPTION
- fix: propagate repository access errors on list, versions etc. to stderr instead of aborting/ignoring
